### PR TITLE
Add support for rounded rectangles based on #29

### DIFF
--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -19,7 +19,7 @@ class SVGRect extends SVGNode
      * @param string|null $width  The width.
      * @param string|null $height The height.
      */
-    public function __construct($x = null, $y = null, $width = null, $height = null)
+    public function __construct($x = null, $y = null, $width = null, $height = null, $rx = null, $ry = null)
     {
         parent::__construct();
 
@@ -27,6 +27,8 @@ class SVGRect extends SVGNode
         $this->setAttributeOptional('y', $y);
         $this->setAttributeOptional('width', $width);
         $this->setAttributeOptional('height', $height);
+        $this->setAttributeOptional('rx', $rx);
+        $this->setAttributeOptional('ry', $ry);
     }
 
 
@@ -71,8 +73,6 @@ class SVGRect extends SVGNode
         return $this->setAttribute('y', $y);
     }
 
-
-
     /**
      * @return string The width.
      */
@@ -110,6 +110,47 @@ class SVGRect extends SVGNode
     }
 
 
+    /**
+     * @return string The rx coordinate of the upper left corner.
+     */
+    public function getRX()
+    {
+        return $this->getAttribute('rx');
+    }
+
+    /**
+     * Sets the rx coordinate of the upper left corner.
+     *
+     * @param string $rx The new coordinate.
+     *
+     * @return $this This node instance, for call chaining.
+     */
+    public function setRX($rx)
+    {
+        return $this->setAttribute('rx', $rx);
+    }
+
+    /**
+     * @return string The ry coordinate of the upper left corner.
+     */
+    public function getRY()
+    {
+        return $this->getAttribute('ry');
+    }
+
+    /**
+     * Sets the ry coordinate of the upper left corner.
+     *
+     * @param string $ry The new coordinate.
+     *
+     * @return $this This node instance, for call chaining.
+     */
+    public function setRY($ry)
+    {
+        return $this->setAttribute('ry', $ry);
+    }
+
+
 
     public function rasterize(SVGRasterizer $rasterizer)
     {
@@ -127,6 +168,8 @@ class SVGRect extends SVGNode
             'y'         => $this->getY(),
             'width'     => $this->getWidth(),
             'height'    => $this->getHeight(),
+            'rx'         => $this->getRX(),
+            'ry'         => $this->getRY(),
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -170,8 +170,8 @@ class SVGRect extends SVGNode
             'y'         => $this->getY(),
             'width'     => $this->getWidth(),
             'height'    => $this->getHeight(),
-            'rx'         => $this->getRX(),
-            'ry'         => $this->getRY(),
+            'rx'        => $this->getRX(),
+            'ry'        => $this->getRY(),
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -113,7 +113,7 @@ class SVGRect extends SVGNode
 
 
     /**
-     * @return string The rx coordinate of the upper left corner.
+     * @return string The x radius of the corners.
      */
     public function getRX()
     {
@@ -121,7 +121,7 @@ class SVGRect extends SVGNode
     }
 
     /**
-     * Sets the rx coordinate of the upper left corner.
+     * Sets the x radius of the corners.
      *
      * @param string $rx The new coordinate.
      *
@@ -133,7 +133,7 @@ class SVGRect extends SVGNode
     }
 
     /**
-     * @return string The ry coordinate of the upper left corner.
+     * @return string The y radius of the corners.
      */
     public function getRY()
     {
@@ -141,7 +141,7 @@ class SVGRect extends SVGNode
     }
 
     /**
-     * Sets the ry coordinate of the upper left corner.
+     * Sets the y radius of the corners.
      *
      * @param string $ry The new coordinate.
      *

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -18,10 +18,8 @@ class SVGRect extends SVGNode
      * @param string|null $y      The y coordinate of the upper left corner.
      * @param string|null $width  The width.
      * @param string|null $height The height.
-     * @param string|null $rx     The x radius of the corners.
-     * @param string|null $ry     The y radius of the corners.
      */
-    public function __construct($x = null, $y = null, $width = null, $height = null, $rx = null, $ry = null)
+    public function __construct($x = null, $y = null, $width = null, $height = null)
     {
         parent::__construct();
 
@@ -29,8 +27,6 @@ class SVGRect extends SVGNode
         $this->setAttributeOptional('y', $y);
         $this->setAttributeOptional('width', $width);
         $this->setAttributeOptional('height', $height);
-        $this->setAttributeOptional('rx', $rx);
-        $this->setAttributeOptional('ry', $ry);
     }
 
 

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -18,6 +18,8 @@ class SVGRect extends SVGNode
      * @param string|null $y      The y coordinate of the upper left corner.
      * @param string|null $width  The width.
      * @param string|null $height The height.
+     * @param string|null $rx     The x radius of the corners.
+     * @param string|null $ry     The y radius of the corners.
      */
     public function __construct($x = null, $y = null, $width = null, $height = null, $rx = null, $ry = null)
     {

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -7,7 +7,7 @@ use SVG\Rasterization\SVGRasterizer;
 
 /**
  * Represents the SVG tag 'rect'.
- * Has the special attributes x, y, width, height.
+ * Has the special attributes x, y, width, height, rx, ry.
  */
 class SVGRect extends SVGNode
 {
@@ -112,6 +112,7 @@ class SVGRect extends SVGNode
     }
 
 
+
     /**
      * @return string The x radius of the corners.
      */
@@ -123,7 +124,7 @@ class SVGRect extends SVGNode
     /**
      * Sets the x radius of the corners.
      *
-     * @param string $rx The new coordinate.
+     * @param string $rx The new radius.
      *
      * @return $this This node instance, for call chaining.
      */
@@ -143,7 +144,7 @@ class SVGRect extends SVGNode
     /**
      * Sets the y radius of the corners.
      *
-     * @param string $ry The new coordinate.
+     * @param string $ry The new radius.
      *
      * @return $this This node instance, for call chaining.
      */

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -219,7 +219,7 @@ class SVGRectRenderer extends SVGRenderer
             $color
         );
 
-        imagesetthickness($image, 1.5);
+        imagesetthickness($image, 1);
 
         for ($sw = -$halfStrokeFloor; $sw < $halfStrokeCeil; ++$sw) {
             // left-top

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -43,7 +43,7 @@ class SVGRectRenderer extends SVGRenderer
         $rx = $params['rx'];
         $ry = $params['ry'];
 
-        if (($rx == 0) && ($ry ===0)) {
+        if (($rx === 0) && ($ry === 0)) {
             imagefilledrectangle(
                 $image,
                 $x1, $y1,
@@ -110,7 +110,7 @@ class SVGRectRenderer extends SVGRenderer
         $halfStrokeFloor = floor($strokeWidth / 2);
         $halfStrokeCeil  = ceil($strokeWidth / 2);
 
-        if (($rx == 0) && ($ry ===0)) {
+        if (($rx === 0) && ($ry === 0)) {
             // top
             imagefilledrectangle(
                 $image,

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -77,26 +77,11 @@ class SVGRectRenderer extends SVGRenderer
         // draws 3 non-overlapping rectangles so that transparency is preserved
 
         // full vertical area
-        imagefilledrectangle(
-            $image,
-            $x1 + $rx, $y1,
-            $x2 - $rx, $y2,
-            $color
-        );
+        imagefilledrectangle($image, $x1 + $rx, $y1, $x2 - $rx, $y2, $color);
         // left side
-        imagefilledrectangle(
-            $image,
-            $x1, $y1 + $ry,
-            $x1 + $rx - 1, $y2 - $ry,
-            $color
-        );
+        imagefilledrectangle($image, $x1, $y1 + $ry, $x1 + $rx - 1, $y2 - $ry, $color);
         // right side
-        imagefilledrectangle(
-            $image,
-            $x2 - $rx + 1, $y1 + $ry,
-            $x2, $y2 - $ry,
-            $color
-        );
+        imagefilledrectangle($image, $x2 - $rx + 1, $y1 + $ry, $x2, $y2 - $ry, $color);
 
         // prepares a separate image containing the corners ellipse, which is
         // then copied onto $image at the corner positions
@@ -105,12 +90,8 @@ class SVGRectRenderer extends SVGRenderer
         imagealphablending($corners, true);
         imagesavealpha($corners, true);
         imagefill($corners, 0, 0, 0x7F000000);
-        imagefilledellipse(
-            $corners,
-            $rx, $ry,
-            $rx * 2, $ry * 2,
-            $color
-        );
+
+        imagefilledellipse($corners, $rx, $ry, $rx * 2, $ry * 2, $color);
 
         // left-top
         imagecopy($image, $corners, $x1, $y1, 0, 0, $rx, $ry);
@@ -220,38 +201,16 @@ class SVGRectRenderer extends SVGRenderer
         imagesetthickness($image, 1);
 
         for ($sw = -$halfStrokeFloor; $sw < $halfStrokeCeil; ++$sw) {
+            $arcW = $rx * 2 + 1 + $sw * 2;
+            $arcH = $ry * 2 + 1 + $sw * 2;
             // left-top
-            imagearc(
-                $image,
-                $x1 + $rx, $y1 + $ry,
-                $rx * 2 + 1 + $sw * 2, $ry * 2 + 1 + $sw * 2,
-                180, 270,
-                $color
-            );
+            imagearc($image, $x1 + $rx, $y1 + $ry, $arcW, $arcH, 180, 270, $color);
             // right-top
-            imagearc(
-                $image,
-                $x2 - $rx, $y1 + $ry,
-                $rx * 2 + 1 + $sw * 2, $ry * 2 + 1 + $sw * 2,
-                270, 360,
-                $color
-            );
+            imagearc($image, $x2 - $rx, $y1 + $ry, $arcW, $arcH, 270, 360, $color);
             // left-bottom
-            imagearc(
-                $image,
-                $x1 + $rx, $y2 - $ry,
-                $rx * 2 + 1 + $sw * 2, $ry * 2 + 1 + $sw * 2,
-                90, 180,
-                $color
-            );
+            imagearc($image, $x1 + $rx, $y2 - $ry, $arcW, $arcH, 90, 180, $color);
             // right-bottom
-            imagearc(
-                $image,
-                $x2 - $rx, $y2 - $ry,
-                $rx * 2 + 1 + $sw * 2, $ry * 2 + 1 + $sw * 2,
-                0, 90,
-                $color
-            );
+            imagearc($image, $x2 - $rx, $y2 - $ry, $arcW, $arcH, 0, 90, $color);
         }
     }
 }

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -23,16 +23,30 @@ class SVGRectRenderer extends SVGRenderer
         $y1 = self::prepareLengthY($options['y'], $rasterizer) + $rasterizer->getOffsetY();
         $w  = self::prepareLengthX($options['width'], $rasterizer);
         $h  = self::prepareLengthY($options['height'], $rasterizer);
-        $rx = self::prepareLengthX($options['rx'], $rasterizer);
-        $ry = self::prepareLengthY($options['ry'], $rasterizer);
+
+        // corner radiuses may at least be (width-1)/2 pixels long.
+        // anything larger than that and the circles start expanding beyond
+        // the rectangle.
+        $rx = empty($options['rx']) ? 0 : self::prepareLengthX($options['rx'], $rasterizer);
+        if ($rx < 0) {
+            $rx = 0;
+        } elseif ($rx > ($w - 1) / 2) {
+            $rx = floor(($w - 1) / 2);
+        }
+        $ry = empty($options['ry']) ? 0 : self::prepareLengthY($options['ry'], $rasterizer);
+        if ($ry < 0) {
+            $ry = 0;
+        } elseif ($ry > ($h - 1) / 2) {
+            $ry = floor(($h - 1) / 2);
+        }
 
         return array(
             'x1' => $x1,
             'y1' => $y1,
             'x2' => $x1 + $w - 1,
             'y2' => $y1 + $h - 1,
-            'rx' => $rx - 1,
-            'ry' => $ry - 1,
+            'rx' => $rx,
+            'ry' => $ry,
         );
     }
 
@@ -78,25 +92,29 @@ class SVGRectRenderer extends SVGRenderer
             $image,
             $x1 + $rx, $y1 + $ry,
             $rx*2, $ry*2,
-            $color);
+            $color
+        );
         // right-top
         imagefilledellipse(
             $image,
             $x2 - $rx, $y1 + $ry,
             $rx*2, $ry*2,
-            $color);
+            $color
+        );
         // left-bottom
         imagefilledellipse(
             $image,
             $x1 + $rx, $y2 - $ry,
             $rx*2, $ry*2,
-            $color);
+            $color
+        );
         // right-bottom
         imagefilledellipse(
             $image,
             $x2 - $rx, $y2 - $ry,
             $rx*2, $ry*2,
-            $color);
+            $color
+        );
     }
 
     protected function renderStroke($image, array $params, $color, $strokeWidth)

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -21,23 +21,74 @@ class SVGRectRenderer extends SVGRenderer
         $y1 = self::prepareLengthY($options['y'], $rasterizer) + $rasterizer->getOffsetY();
         $w  = self::prepareLengthX($options['width'], $rasterizer);
         $h  = self::prepareLengthY($options['height'], $rasterizer);
+        $rx = self::prepareLengthX($options['rx'], $rasterizer);
+        $ry = self::prepareLengthY($options['ry'], $rasterizer);
 
         return array(
             'x1' => $x1,
             'y1' => $y1,
             'x2' => $x1 + $w - 1,
             'y2' => $y1 + $h - 1,
+            'rx' => $rx - 1,
+            'ry' => $ry - 1,
         );
     }
 
     protected function renderFill($image, array $params, $color)
     {
-        imagefilledrectangle(
-            $image,
-            $params['x1'], $params['y1'],
-            $params['x2'], $params['y2'],
-            $color
-        );
+        $x1 = $params['x1'];
+        $y1 = $params['y1'];
+        $x2 = $params['x2'];
+        $y2 = $params['y2'];
+        $rx = $params['rx'];
+        $ry = $params['ry'];
+
+        if (($rx == 0) && ($ry ===0)) {
+            imagefilledrectangle(
+                $image,
+                $x1, $y1,
+                $x2, $y2,
+                $color
+            );
+        } else {
+            imagefilledrectangle(
+                $image,
+                $x1 + $rx, $y1,
+                $x2 - $rx, $y2,
+                $color
+            );
+            imagefilledrectangle(
+                $image,
+                $x1, $y1 + $ry,
+                $x2, $y2 - $ry,
+                $color
+            );
+
+            // left-top
+            imagefilledellipse(
+                $image,
+                $x1 + $rx, $y1 + $ry,
+                $rx*2, $ry*2,
+                $color);
+            // right-top
+            imagefilledellipse(
+                $image,
+                $x2 - $rx, $y1 + $ry,
+                $rx*2, $ry*2,
+                $color);
+            // left-bottom
+            imagefilledellipse(
+                $image,
+                $x1 + $rx, $y2 - $ry,
+                $rx*2, $ry*2,
+                $color);
+            // right-bottom
+            imagefilledellipse(
+                $image,
+                $x2 - $rx, $y2 - $ry,
+                $rx*2, $ry*2,
+                $color);
+        }
     }
 
     protected function renderStroke($image, array $params, $color, $strokeWidth)
@@ -48,6 +99,8 @@ class SVGRectRenderer extends SVGRenderer
         $y1 = $params['y1'];
         $x2 = $params['x2'];
         $y2 = $params['y2'];
+        $rx = $params['rx'];
+        $ry = $params['ry'];
 
         // imagerectangle draws left and right side 1px thicker than it should,
         // and drawing 4 lines instead doesn't work either because of
@@ -57,33 +110,96 @@ class SVGRectRenderer extends SVGRenderer
         $halfStrokeFloor = floor($strokeWidth / 2);
         $halfStrokeCeil  = ceil($strokeWidth / 2);
 
-        // top
-        imagefilledrectangle(
-            $image,
-            $x1 - $halfStrokeFloor,     $y1 - $halfStrokeFloor,
-            $x2 + $halfStrokeFloor,     $y1 + $halfStrokeCeil - 1,
-            $color
-        );
-        // bottom
-        imagefilledrectangle(
-            $image,
-            $x1 - $halfStrokeFloor,     $y2 - $halfStrokeCeil + 1,
-            $x2 + $halfStrokeFloor,     $y2 + $halfStrokeFloor,
-            $color
-        );
-        // left
-        imagefilledrectangle(
-            $image,
-            $x1 - $halfStrokeFloor,     $y1 + $halfStrokeCeil,
-            $x1 + $halfStrokeCeil - 1,  $y2 - $halfStrokeCeil,
-            $color
-        );
-        // right
-        imagefilledrectangle(
-            $image,
-            $x2 - $halfStrokeCeil + 1,  $y1 + $halfStrokeCeil,
-            $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil,
-            $color
-        );
+        if (($rx == 0) && ($ry ===0)) {
+            // top
+            imagefilledrectangle(
+                $image,
+                $x1 - $halfStrokeFloor,     $y1 - $halfStrokeFloor,
+                $x2 + $halfStrokeFloor,     $y1 + $halfStrokeCeil - 1,
+                $color
+            );
+            // bottom
+            imagefilledrectangle(
+                $image,
+                $x1 - $halfStrokeFloor,     $y2 - $halfStrokeCeil + 1,
+                $x2 + $halfStrokeFloor,     $y2 + $halfStrokeFloor,
+                $color
+            );
+            // left
+            imagefilledrectangle(
+                $image,
+                $x1 - $halfStrokeFloor,     $y1 + $halfStrokeCeil,
+                $x1 + $halfStrokeCeil - 1,  $y2 - $halfStrokeCeil,
+                $color
+            );
+            // right
+            imagefilledrectangle(
+                $image,
+                $x2 - $halfStrokeCeil + 1,  $y1 + $halfStrokeCeil,
+                $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil,
+                $color
+            );
+        } else {
+            // top
+            imagefilledrectangle(
+                $image,
+                $x1 - $halfStrokeFloor + $rx*1.5,     $y1 - $halfStrokeFloor,
+                $x2 + $halfStrokeFloor - $rx*1.5,     $y1 + $halfStrokeCeil - 1,
+                $color
+            );
+            // bottom
+            imagefilledrectangle(
+                $image,
+                $x1 - $halfStrokeFloor + $rx*1.5,     $y2 - $halfStrokeCeil + 1,
+                $x2 + $halfStrokeFloor - $rx*1.5,     $y2 + $halfStrokeFloor,
+                $color
+            );
+            // left
+            imagefilledrectangle(
+                $image,
+                $x1 - $halfStrokeFloor,     $y1 + $halfStrokeCeil + $ry/2,
+                $x1 + $halfStrokeCeil - 1,  $y2 - $halfStrokeCeil - $ry/2,
+                $color
+            );
+            // right
+            imagefilledrectangle(
+                $image,
+                $x2 - $halfStrokeCeil + 1,  $y1 + $halfStrokeCeil + $ry/2,
+                $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil - $ry/2,
+                $color
+            );
+            imagesetthickness($image, 1.5);
+            for ($sw = $strokeWidth  ; $sw >= -$halfStrokeCeil; $sw --) {
+                // left-top
+                imagearc(
+                    $image,
+                    $x1 + $rx, $y1 + $ry,
+                    $rx*2+$sw, $ry*2+$sw,
+                    180-1, 270+1,
+                    $color);
+                // 0x00FF0000);
+                // right-top
+                imagearc(
+                    $image,
+                    $x2 - $rx, $y1 + $ry,
+                    $rx*2+$sw, $ry*2+$sw,
+                    270, 360,
+                    $color);
+                // left-bottom
+                imagearc(
+                    $image,
+                    $x1 + $rx, $y2 - $ry,
+                    $rx*2+$sw, $ry*2+$sw,
+                    90,180,
+                    $color);
+                // right-bottom
+                imagearc(
+                    $image,
+                    $x2 - $rx, $y2 - $ry,
+                    $rx*2+$sw, $ry*2+$sw,
+                    0, 90,
+                    $color);
+            }
+        }
     }
 }

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -12,6 +12,8 @@ use SVG\Rasterization\SVGRasterizer;
  * - float y: the y coordinate of the upper left corner
  * - float width: the width
  * - float height: the height
+ * - float rx: the x radius of the corners.
+ * - float ry: the y radius of the corners.
  */
 class SVGRectRenderer extends SVGRenderer
 {

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -175,9 +175,8 @@ class SVGRectRenderer extends SVGRenderer
                     $image,
                     $x1 + $rx, $y1 + $ry,
                     $rx*2+$sw, $ry*2+$sw,
-                    180-1, 270+1,
+                    180, 270,
                     $color);
-                // 0x00FF0000);
                 // right-top
                 imagearc(
                     $image,

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -112,8 +112,6 @@ class SVGRectRenderer extends SVGRenderer
             $color
         );
 
-        imagepng($corners, 'corners.png', 9);
-
         // left-top
         imagecopy($image, $corners, $x1, $y1, 0, 0, $rx, $ry);
         // right-top

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -193,40 +193,40 @@ class SVGRectRenderer extends SVGRenderer
         // top
         imagefilledrectangle(
             $image,
-            $x1 - $halfStrokeFloor + $rx*1.5,  $y1 - $halfStrokeFloor,
-            $x2 + $halfStrokeFloor - $rx*1.5,  $y1 + $halfStrokeCeil - 1,
+            $x1 + $rx + 1,  $y1 - $halfStrokeFloor,
+            $x2 - $rx - 1,  $y1 + $halfStrokeCeil - 1,
             $color
         );
         // bottom
         imagefilledrectangle(
             $image,
-            $x1 - $halfStrokeFloor + $rx*1.5,  $y2 - $halfStrokeCeil + 1,
-            $x2 + $halfStrokeFloor - $rx*1.5,  $y2 + $halfStrokeFloor,
+            $x1 + $rx + 1,  $y2 - $halfStrokeCeil + 1,
+            $x2 - $rx - 1,  $y2 + $halfStrokeFloor,
             $color
         );
         // left
         imagefilledrectangle(
             $image,
-            $x1 - $halfStrokeFloor,     $y1 + $halfStrokeCeil + $ry/2,
-            $x1 + $halfStrokeCeil - 1,  $y2 - $halfStrokeCeil - $ry/2,
+            $x1 - $halfStrokeFloor,     $y1 + $ry + 1,
+            $x1 + $halfStrokeCeil - 1,  $y2 - $ry - 1,
             $color
         );
         // right
         imagefilledrectangle(
             $image,
-            $x2 - $halfStrokeCeil + 1,  $y1 + $halfStrokeCeil + $ry/2,
-            $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil - $ry/2,
+            $x2 - $halfStrokeCeil + 1,  $y1 + $ry + 1,
+            $x2 + $halfStrokeFloor,     $y2 - $ry - 1,
             $color
         );
 
         imagesetthickness($image, 1.5);
 
-        for ($sw = $strokeWidth; $sw >= -$halfStrokeCeil; --$sw) {
+        for ($sw = -$halfStrokeFloor; $sw < $halfStrokeCeil; ++$sw) {
             // left-top
             imagearc(
                 $image,
                 $x1 + $rx, $y1 + $ry,
-                $rx*2+$sw, $ry*2+$sw,
+                $rx * 2 + 1 + $sw * 2, $ry * 2 + 1 + $sw * 2,
                 180, 270,
                 $color
             );
@@ -234,7 +234,7 @@ class SVGRectRenderer extends SVGRenderer
             imagearc(
                 $image,
                 $x2 - $rx, $y1 + $ry,
-                $rx*2+$sw, $ry*2+$sw,
+                $rx * 2 + 1 + $sw * 2, $ry * 2 + 1 + $sw * 2,
                 270, 360,
                 $color
             );
@@ -242,15 +242,15 @@ class SVGRectRenderer extends SVGRenderer
             imagearc(
                 $image,
                 $x1 + $rx, $y2 - $ry,
-                $rx*2+$sw, $ry*2+$sw,
-                90,180,
+                $rx * 2 + 1 + $sw * 2, $ry * 2 + 1 + $sw * 2,
+                90, 180,
                 $color
             );
             // right-bottom
             imagearc(
                 $image,
                 $x2 - $rx, $y2 - $ry,
-                $rx*2+$sw, $ry*2+$sw,
+                $rx * 2 + 1 + $sw * 2, $ry * 2 + 1 + $sw * 2,
                 0, 90,
                 $color
             );

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -38,26 +38,21 @@ class SVGRectRenderer extends SVGRenderer
 
     protected function renderFill($image, array $params, $color)
     {
-        $x1 = $params['x1'];
-        $y1 = $params['y1'];
-        $x2 = $params['x2'];
-        $y2 = $params['y2'];
-        $rx = $params['rx'];
-        $ry = $params['ry'];
-
-        if (($rx !== 0) || ($ry !== 0)) {
+        if ($params['rx'] !== 0 || $params['ry'] !== 0) {
             self::renderFillRounded($image, $params, $color);
-            return ;
+            return;
         }
+
         imagefilledrectangle(
             $image,
-            $x1, $y1,
-            $x2, $y2,
+            $params['x1'], $params['y1'],
+            $params['x2'], $params['y2'],
             $color
         );
     }
 
-    private function renderFillRounded($image, array $params, $color) {
+    private function renderFillRounded($image, array $params, $color)
+    {
         $x1 = $params['x1'];
         $y1 = $params['y1'];
         $x2 = $params['x2'];
@@ -77,7 +72,7 @@ class SVGRectRenderer extends SVGRenderer
             $x2, $y2 - $ry,
             $color
         );
-        
+
         // left-top
         imagefilledellipse(
             $image,
@@ -103,7 +98,7 @@ class SVGRectRenderer extends SVGRenderer
             $rx*2, $ry*2,
             $color);
     }
-    
+
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
         imagesetthickness($image, $strokeWidth);
@@ -157,7 +152,8 @@ class SVGRectRenderer extends SVGRenderer
         );
     }
 
-    private function renderStrokeRounded($image, array $params, $color, $strokeWidth) {
+    private function renderStrokeRounded($image, array $params, $color, $strokeWidth)
+    {
         $x1 = $params['x1'];
         $y1 = $params['y1'];
         $x2 = $params['x2'];
@@ -196,36 +192,42 @@ class SVGRectRenderer extends SVGRenderer
             $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil - $ry/2,
             $color
         );
+
         imagesetthickness($image, 1.5);
-        for ($sw = $strokeWidth  ; $sw >= -$halfStrokeCeil; $sw --) {
+
+        for ($sw = $strokeWidth; $sw >= -$halfStrokeCeil; --$sw) {
             // left-top
             imagearc(
                 $image,
                 $x1 + $rx, $y1 + $ry,
                 $rx*2+$sw, $ry*2+$sw,
                 180, 270,
-                $color);
+                $color
+            );
             // right-top
             imagearc(
                 $image,
                 $x2 - $rx, $y1 + $ry,
                 $rx*2+$sw, $ry*2+$sw,
                 270, 360,
-                $color);
+                $color
+            );
             // left-bottom
             imagearc(
                 $image,
                 $x1 + $rx, $y2 - $ry,
                 $rx*2+$sw, $ry*2+$sw,
                 90,180,
-                $color);
+                $color
+            );
             // right-bottom
             imagearc(
                 $image,
                 $x2 - $rx, $y2 - $ry,
                 $rx*2+$sw, $ry*2+$sw,
                 0, 90,
-                $color);
+                $color
+            );
         }
     }
 }

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -43,16 +43,16 @@ class SVGRectRenderer extends SVGRenderer
         $rx = $params['rx'];
         $ry = $params['ry'];
 
-        if (($rx !== 0) && ($ry !== 0)) {
+        if (($rx !== 0) || ($ry !== 0)) {
             self::renderFillRounded($image, $params, $color);
-        } else {
-            imagefilledrectangle(
-                $image,
-                $x1, $y1,
-                $x2, $y2,
-                $color
-            );
+            return ;
         }
+        imagefilledrectangle(
+            $image,
+            $x1, $y1,
+            $x2, $y2,
+            $color
+        );
     }
 
     private function renderFillRounded($image, array $params, $color) {
@@ -121,38 +121,38 @@ class SVGRectRenderer extends SVGRenderer
         $halfStrokeFloor = floor($strokeWidth / 2);
         $halfStrokeCeil  = ceil($strokeWidth / 2);
 
-        if (($rx !== 0) && ($ry !== 0)) {
+        if (($rx !== 0) || ($ry !== 0)) {
             self::renderStrokeRounded($image, $params, $color, $strokeWidth);
-        } else {
-            // top
-            imagefilledrectangle(
-                $image,
-                $x1 - $halfStrokeFloor,     $y1 - $halfStrokeFloor,
-                $x2 + $halfStrokeFloor,     $y1 + $halfStrokeCeil - 1,
-                $color
-            );
-            // bottom
-            imagefilledrectangle(
-                $image,
-                $x1 - $halfStrokeFloor,     $y2 - $halfStrokeCeil + 1,
-                $x2 + $halfStrokeFloor,     $y2 + $halfStrokeFloor,
-                $color
-            );
-            // left
-            imagefilledrectangle(
-                $image,
-                $x1 - $halfStrokeFloor,     $y1 + $halfStrokeCeil,
-                $x1 + $halfStrokeCeil - 1,  $y2 - $halfStrokeCeil,
-                $color
-            );
-            // right
-            imagefilledrectangle(
-                $image,
-                $x2 - $halfStrokeCeil + 1,  $y1 + $halfStrokeCeil,
-                $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil,
-                $color
-            );
+            return ;
         }
+        // top
+        imagefilledrectangle(
+            $image,
+            $x1 - $halfStrokeFloor,     $y1 - $halfStrokeFloor,
+            $x2 + $halfStrokeFloor,     $y1 + $halfStrokeCeil - 1,
+            $color
+        );
+        // bottom
+        imagefilledrectangle(
+            $image,
+            $x1 - $halfStrokeFloor,     $y2 - $halfStrokeCeil + 1,
+            $x2 + $halfStrokeFloor,     $y2 + $halfStrokeFloor,
+            $color
+        );
+        // left
+        imagefilledrectangle(
+            $image,
+            $x1 - $halfStrokeFloor,     $y1 + $halfStrokeCeil,
+            $x1 + $halfStrokeCeil - 1,  $y2 - $halfStrokeCeil,
+            $color
+        );
+        // right
+        imagefilledrectangle(
+            $image,
+            $x2 - $halfStrokeCeil + 1,  $y1 + $halfStrokeCeil,
+            $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil,
+            $color
+        );
     }
 
     private function renderStrokeRounded($image, array $params, $color, $strokeWidth) {

--- a/src/Rasterization/Renderers/SVGRectRenderer.php
+++ b/src/Rasterization/Renderers/SVGRectRenderer.php
@@ -43,54 +43,65 @@ class SVGRectRenderer extends SVGRenderer
         $rx = $params['rx'];
         $ry = $params['ry'];
 
-        if (($rx === 0) && ($ry === 0)) {
+        if (($rx !== 0) && ($ry !== 0)) {
+            self::renderFillRounded($image, $params, $color);
+        } else {
             imagefilledrectangle(
                 $image,
                 $x1, $y1,
                 $x2, $y2,
                 $color
             );
-        } else {
-            imagefilledrectangle(
-                $image,
-                $x1 + $rx, $y1,
-                $x2 - $rx, $y2,
-                $color
-            );
-            imagefilledrectangle(
-                $image,
-                $x1, $y1 + $ry,
-                $x2, $y2 - $ry,
-                $color
-            );
-
-            // left-top
-            imagefilledellipse(
-                $image,
-                $x1 + $rx, $y1 + $ry,
-                $rx*2, $ry*2,
-                $color);
-            // right-top
-            imagefilledellipse(
-                $image,
-                $x2 - $rx, $y1 + $ry,
-                $rx*2, $ry*2,
-                $color);
-            // left-bottom
-            imagefilledellipse(
-                $image,
-                $x1 + $rx, $y2 - $ry,
-                $rx*2, $ry*2,
-                $color);
-            // right-bottom
-            imagefilledellipse(
-                $image,
-                $x2 - $rx, $y2 - $ry,
-                $rx*2, $ry*2,
-                $color);
         }
     }
 
+    private function renderFillRounded($image, array $params, $color) {
+        $x1 = $params['x1'];
+        $y1 = $params['y1'];
+        $x2 = $params['x2'];
+        $y2 = $params['y2'];
+        $rx = $params['rx'];
+        $ry = $params['ry'];
+
+        imagefilledrectangle(
+            $image,
+            $x1 + $rx, $y1,
+            $x2 - $rx, $y2,
+            $color
+        );
+        imagefilledrectangle(
+            $image,
+            $x1, $y1 + $ry,
+            $x2, $y2 - $ry,
+            $color
+        );
+        
+        // left-top
+        imagefilledellipse(
+            $image,
+            $x1 + $rx, $y1 + $ry,
+            $rx*2, $ry*2,
+            $color);
+        // right-top
+        imagefilledellipse(
+            $image,
+            $x2 - $rx, $y1 + $ry,
+            $rx*2, $ry*2,
+            $color);
+        // left-bottom
+        imagefilledellipse(
+            $image,
+            $x1 + $rx, $y2 - $ry,
+            $rx*2, $ry*2,
+            $color);
+        // right-bottom
+        imagefilledellipse(
+            $image,
+            $x2 - $rx, $y2 - $ry,
+            $rx*2, $ry*2,
+            $color);
+    }
+    
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
         imagesetthickness($image, $strokeWidth);
@@ -110,7 +121,9 @@ class SVGRectRenderer extends SVGRenderer
         $halfStrokeFloor = floor($strokeWidth / 2);
         $halfStrokeCeil  = ceil($strokeWidth / 2);
 
-        if (($rx === 0) && ($ry === 0)) {
+        if (($rx !== 0) && ($ry !== 0)) {
+            self::renderStrokeRounded($image, $params, $color, $strokeWidth);
+        } else {
             // top
             imagefilledrectangle(
                 $image,
@@ -139,66 +152,78 @@ class SVGRectRenderer extends SVGRenderer
                 $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil,
                 $color
             );
-        } else {
-            // top
-            imagefilledrectangle(
+        }
+    }
+
+    private function renderStrokeRounded($image, array $params, $color, $strokeWidth) {
+        $x1 = $params['x1'];
+        $y1 = $params['y1'];
+        $x2 = $params['x2'];
+        $y2 = $params['y2'];
+        $rx = $params['rx'];
+        $ry = $params['ry'];
+
+        $halfStrokeFloor = floor($strokeWidth / 2);
+        $halfStrokeCeil  = ceil($strokeWidth / 2);
+
+        // top
+        imagefilledrectangle(
+            $image,
+            $x1 - $halfStrokeFloor + $rx*1.5,  $y1 - $halfStrokeFloor,
+            $x2 + $halfStrokeFloor - $rx*1.5,  $y1 + $halfStrokeCeil - 1,
+            $color
+        );
+        // bottom
+        imagefilledrectangle(
+            $image,
+            $x1 - $halfStrokeFloor + $rx*1.5,  $y2 - $halfStrokeCeil + 1,
+            $x2 + $halfStrokeFloor - $rx*1.5,  $y2 + $halfStrokeFloor,
+            $color
+        );
+        // left
+        imagefilledrectangle(
+            $image,
+            $x1 - $halfStrokeFloor,     $y1 + $halfStrokeCeil + $ry/2,
+            $x1 + $halfStrokeCeil - 1,  $y2 - $halfStrokeCeil - $ry/2,
+            $color
+        );
+        // right
+        imagefilledrectangle(
+            $image,
+            $x2 - $halfStrokeCeil + 1,  $y1 + $halfStrokeCeil + $ry/2,
+            $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil - $ry/2,
+            $color
+        );
+        imagesetthickness($image, 1.5);
+        for ($sw = $strokeWidth  ; $sw >= -$halfStrokeCeil; $sw --) {
+            // left-top
+            imagearc(
                 $image,
-                $x1 - $halfStrokeFloor + $rx*1.5,     $y1 - $halfStrokeFloor,
-                $x2 + $halfStrokeFloor - $rx*1.5,     $y1 + $halfStrokeCeil - 1,
-                $color
-            );
-            // bottom
-            imagefilledrectangle(
+                $x1 + $rx, $y1 + $ry,
+                $rx*2+$sw, $ry*2+$sw,
+                180, 270,
+                $color);
+            // right-top
+            imagearc(
                 $image,
-                $x1 - $halfStrokeFloor + $rx*1.5,     $y2 - $halfStrokeCeil + 1,
-                $x2 + $halfStrokeFloor - $rx*1.5,     $y2 + $halfStrokeFloor,
-                $color
-            );
-            // left
-            imagefilledrectangle(
+                $x2 - $rx, $y1 + $ry,
+                $rx*2+$sw, $ry*2+$sw,
+                270, 360,
+                $color);
+            // left-bottom
+            imagearc(
                 $image,
-                $x1 - $halfStrokeFloor,     $y1 + $halfStrokeCeil + $ry/2,
-                $x1 + $halfStrokeCeil - 1,  $y2 - $halfStrokeCeil - $ry/2,
-                $color
-            );
-            // right
-            imagefilledrectangle(
+                $x1 + $rx, $y2 - $ry,
+                $rx*2+$sw, $ry*2+$sw,
+                90,180,
+                $color);
+            // right-bottom
+            imagearc(
                 $image,
-                $x2 - $halfStrokeCeil + 1,  $y1 + $halfStrokeCeil + $ry/2,
-                $x2 + $halfStrokeFloor,     $y2 - $halfStrokeCeil - $ry/2,
-                $color
-            );
-            imagesetthickness($image, 1.5);
-            for ($sw = $strokeWidth  ; $sw >= -$halfStrokeCeil; $sw --) {
-                // left-top
-                imagearc(
-                    $image,
-                    $x1 + $rx, $y1 + $ry,
-                    $rx*2+$sw, $ry*2+$sw,
-                    180, 270,
-                    $color);
-                // right-top
-                imagearc(
-                    $image,
-                    $x2 - $rx, $y1 + $ry,
-                    $rx*2+$sw, $ry*2+$sw,
-                    270, 360,
-                    $color);
-                // left-bottom
-                imagearc(
-                    $image,
-                    $x1 + $rx, $y2 - $ry,
-                    $rx*2+$sw, $ry*2+$sw,
-                    90,180,
-                    $color);
-                // right-bottom
-                imagearc(
-                    $image,
-                    $x2 - $rx, $y2 - $ry,
-                    $rx*2+$sw, $ry*2+$sw,
-                    0, 90,
-                    $color);
-            }
+                $x2 - $rx, $y2 - $ry,
+                $rx*2+$sw, $ry*2+$sw,
+                0, 90,
+                $color);
         }
     }
 }


### PR DESCRIPTION
Adds support for the `rx` and `ry` attributes on the `<rect>` element.

* The `SVGRect` class receives new getters and setters for those attributes.
* `SVGRectRenderer` is adapted to support rendering the rounded corners.