### PR TITLE
Returns text content that is directly in this element.

### DIFF
--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -16,11 +16,14 @@ abstract class SVGNode
     protected $styles;
     /** @var string[] $attributes This node's set of attributes. */
     protected $attributes;
+    /** @var string $value This node's value */
+    protected $value;
 
     public function __construct()
     {
         $this->styles     = array();
         $this->attributes = array();
+        $this->value      = '';
     }
 
     /**
@@ -57,6 +60,35 @@ abstract class SVGNode
     public function getParent()
     {
         return $this->parent;
+    }
+
+
+
+    /**
+     * Obtains the value on this node.
+     *
+     * @return string The node's value
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Defines the value on this node.
+     *
+     * @param string $value The new node's value.
+     *
+     * @return $this This node instance, for call chaining.
+     */
+    public function setValue($value)
+    {
+        if (!isset($value)) {
+            unset($this->value);
+            return $this;
+        }
+        $this->value = (string) $value;
+        return $this;
     }
 
 

--- a/src/Nodes/Texts/SVGText.php
+++ b/src/Nodes/Texts/SVGText.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SVG\Nodes\Texts;
+
+use SVG\Nodes\SVGNodeContainer;
+
+/**
+ * Represents the SVG tag 'text'.
+ */
+class SVGText extends SVGNodeContainer
+{
+    const TAG_NAME = 'text';
+}

--- a/src/Nodes/Texts/SVGTextPath.php
+++ b/src/Nodes/Texts/SVGTextPath.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SVG\Nodes\Texts;
+
+use SVG\Nodes\SVGNodeContainer;
+
+/**
+ * Represents the SVG tag 'textPath'.
+ */
+class SVGTextPath extends SVGNodeContainer
+{
+    const TAG_NAME = 'textPath';
+}

--- a/src/Reading/SVGReader.php
+++ b/src/Reading/SVGReader.php
@@ -31,6 +31,8 @@ class SVGReader
         'polyline'  => 'SVG\Nodes\Shapes\SVGPolyline',
         'path'      => 'SVG\Nodes\Shapes\SVGPath',
         'image'     => 'SVG\Nodes\Embedded\SVGImageElement',
+        'text'      => 'SVG\Nodes\Texts\SVGText',
+        'textPath'  => 'SVG\Nodes\Texts\SVGTextPath',
     );
     /**
      * @var string[] @styleAttributes Attributes to be interpreted as styles.
@@ -205,10 +207,9 @@ class SVGReader
     {
         foreach ($xml->children() as $child) {
             $childNode = $this->parseNode($child, $namespaces);
-            if (!$childNode) {
-                continue;
+            if ($childNode) {
+                $node->addChild($childNode);
             }
-            $node->addChild($childNode);
         }
     }
 
@@ -234,6 +235,7 @@ class SVGReader
 
         $this->applyAttributes($node, $xml, $namespaces);
         $this->applyStyles($node, $xml);
+        $node->setValue($xml);
 
         if ($node instanceof SVGNodeContainer) {
             $this->addChildren($node, $xml, $namespaces);

--- a/src/Writing/SVGWriter.php
+++ b/src/Writing/SVGWriter.php
@@ -57,7 +57,7 @@ class SVGWriter
         $this->outString .= '>';
         if ($node instanceof SVGStyle) {
             $this->writeCdata($node->getCss());
-            $this->outString .= '</'.$node->getName().'>';
+            $this->outString .= $node->getValue().'</'.$node->getName().'>';
 
             return;
         }
@@ -65,7 +65,7 @@ class SVGWriter
         for ($i = 0, $n = $node->countChildren(); $i < $n; ++$i) {
             $this->writeNode($node->getChild($i));
         }
-        $this->outString .= '</'.$node->getName().'>';
+        $this->outString .= $node->getValue().'</'.$node->getName().'>';
     }
 
     /**


### PR DESCRIPTION
9a490f7 : Allows to retrieve the value of a xml tag ([see __toString of \SimpleXMLElement](http://php.net/manual/en/simplexmlelement.tostring.php))

cf6c017 : Add node text and textPath (do not implement rasterize)
