### PR TITLE
Add title type

### DIFF
--- a/src/Nodes/Texts/SVGTitle.php
+++ b/src/Nodes/Texts/SVGTitle.php
@@ -1,0 +1,22 @@
+<?php
+namespace SVG\Nodes\Texts;
+use SVG\Nodes\SVGNode;
+use SVG\Rasterization\SVGRasterizer;
+/**
+ * Represents the SVG tag 'title'.
+ * Has the attribute 'text'.
+ */
+class SVGTitle extends SVGNode
+{
+    const TAG_NAME = 'title';
+
+    /**
+     * Dummy implementation
+     *
+     * @param SVGRasterizer $rasterizer
+     */
+    public function rasterize(SVGRasterizer $rasterizer)
+    {
+        // nothing to rasterize
+    }
+}

--- a/src/Nodes/Texts/SVGTitle.php
+++ b/src/Nodes/Texts/SVGTitle.php
@@ -14,6 +14,8 @@ class SVGTitle extends SVGNode
      * Dummy implementation
      *
      * @param SVGRasterizer $rasterizer
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Reading/SVGReader.php
+++ b/src/Reading/SVGReader.php
@@ -33,6 +33,7 @@ class SVGReader
         'image'     => 'SVG\Nodes\Embedded\SVGImageElement',
         'text'      => 'SVG\Nodes\Texts\SVGText',
         'textPath'  => 'SVG\Nodes\Texts\SVGTextPath',
+        'title'     => 'SVG\Nodes\Texts\SVGTitle',
     );
     /**
      * @var string[] @styleAttributes Attributes to be interpreted as styles.

--- a/src/Writing/SVGWriter.php
+++ b/src/Writing/SVGWriter.php
@@ -66,7 +66,7 @@ class SVGWriter
         for ($i = 0, $n = $node->countChildren(); $i < $n; ++$i) {
             $this->writeNode($node->getChild($i));
         }
-        $this->outString .= $node->getValue().'</'.$node->getName().'>';
+        $this->outString .= htmlspecialchars($node->getValue()).'</'.$node->getName().'>';
     }
 
     /**

--- a/src/Writing/SVGWriter.php
+++ b/src/Writing/SVGWriter.php
@@ -50,23 +50,29 @@ class SVGWriter
         $this->appendAttributes($node->getSerializableAttributes());
         $this->appendStyles($node->getSerializableStyles());
 
-        if (!($node instanceof SVGNodeContainer) && !($node instanceof SVGStyle)) {
-            $this->outString .= ' />';
+        $textContent = htmlspecialchars($node->getValue());
+
+        if ($node instanceof SVGNodeContainer) {
+            $this->outString .= '>';
+            for ($i = 0, $n = $node->countChildren(); $i < $n; ++$i) {
+                $this->writeNode($node->getChild($i));
+            }
+            $this->outString .= $textContent.'</'.$node->getName().'>';
             return;
         }
 
-        $this->outString .= '>';
         if ($node instanceof SVGStyle) {
+            $this->outString .= '>';
             $this->writeCdata($node->getCss());
-            $this->outString .= $node->getValue().'</'.$node->getName().'>';
-
+            $this->outString .= $textContent.'</'.$node->getName().'>';
             return;
         }
 
-        for ($i = 0, $n = $node->countChildren(); $i < $n; ++$i) {
-            $this->writeNode($node->getChild($i));
+        if (!empty($textContent)) {
+            $this->outString .= '>' . $textContent . '</'.$node->getName().'>';
         }
-        $this->outString .= htmlspecialchars($node->getValue()).'</'.$node->getName().'>';
+
+        $this->outString .= ' />';
     }
 
     /**

--- a/src/Writing/SVGWriter.php
+++ b/src/Writing/SVGWriter.php
@@ -70,6 +70,7 @@ class SVGWriter
 
         if (!empty($textContent)) {
             $this->outString .= '>' . $textContent . '</'.$node->getName().'>';
+            return;
         }
 
         $this->outString .= ' />';


### PR DESCRIPTION
There are many use-cases for this library where one is actually more in the SVG itself than in the rasterized image-file.
In these use-cases, it might be nice to have a simple mouse-over text over some elements of the SVG. The [`<title>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title) element implements that functionality.

This pull request further fixes an possible xss attack in the text nodes and refactors the `writeNode` method.