### PR TITLE
Add link to Wiki for additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,5 @@ echo $image;
 
 For loading from a file instead, you would call `SVG::fromFile($file)`.
 That function supports local file paths as well as URLs.
+
+For additional documentation, see the [wiki](https://github.com/meyfa/php-svg/wiki).


### PR DESCRIPTION
This PR adds a link to the wiki at the bottom of README.md. It took me an hour or two of using the software and trying to figure out how to draw shapes with it, before I discovered the additional documentation in the wiki. By adding this link I hope to make the wiki more apparent to new users. That will in turn hopefully result in more edits to the wiki, to further improve the docs.