### PR TITLE
Add @inheritdoc to every inherited method

### DIFF
--- a/src/Nodes/Embedded/SVGForeignObject.php
+++ b/src/Nodes/Embedded/SVGForeignObject.php
@@ -18,9 +18,7 @@ class SVGForeignObject extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Embedded/SVGImage.php
+++ b/src/Nodes/Embedded/SVGImage.php
@@ -191,6 +191,9 @@ class SVGImage extends SVGNodeContainer
         return $this->setAttribute('height', $height);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {

--- a/src/Nodes/Filters/SVGFEBlend.php
+++ b/src/Nodes/Filters/SVGFEBlend.php
@@ -18,9 +18,7 @@ class SVGFEBlend extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEColorMatrix.php
+++ b/src/Nodes/Filters/SVGFEColorMatrix.php
@@ -18,9 +18,7 @@ class SVGFEColorMatrix extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEComponentTransfer.php
+++ b/src/Nodes/Filters/SVGFEComponentTransfer.php
@@ -18,9 +18,7 @@ class SVGFEComponentTransfer extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEComposite.php
+++ b/src/Nodes/Filters/SVGFEComposite.php
@@ -18,9 +18,7 @@ class SVGFEComposite extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEConvolveMatrix.php
+++ b/src/Nodes/Filters/SVGFEConvolveMatrix.php
@@ -18,9 +18,7 @@ class SVGFEConvolveMatrix extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEDiffuseLighting.php
+++ b/src/Nodes/Filters/SVGFEDiffuseLighting.php
@@ -18,9 +18,7 @@ class SVGFEDiffuseLighting extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEDisplacementMap.php
+++ b/src/Nodes/Filters/SVGFEDisplacementMap.php
@@ -18,9 +18,7 @@ class SVGFEDisplacementMap extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEDistantLight.php
+++ b/src/Nodes/Filters/SVGFEDistantLight.php
@@ -18,9 +18,7 @@ class SVGFEDistantLight extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEDropShadow.php
+++ b/src/Nodes/Filters/SVGFEDropShadow.php
@@ -18,9 +18,7 @@ class SVGFEDropShadow extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEFlood.php
+++ b/src/Nodes/Filters/SVGFEFlood.php
@@ -18,9 +18,7 @@ class SVGFEFlood extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEFuncA.php
+++ b/src/Nodes/Filters/SVGFEFuncA.php
@@ -18,9 +18,7 @@ class SVGFEFuncA extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEFuncB.php
+++ b/src/Nodes/Filters/SVGFEFuncB.php
@@ -18,9 +18,7 @@ class SVGFEFuncB extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEFuncG.php
+++ b/src/Nodes/Filters/SVGFEFuncG.php
@@ -18,9 +18,7 @@ class SVGFEFuncG extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEFuncR.php
+++ b/src/Nodes/Filters/SVGFEFuncR.php
@@ -18,9 +18,7 @@ class SVGFEFuncR extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEGaussianBlur.php
+++ b/src/Nodes/Filters/SVGFEGaussianBlur.php
@@ -18,9 +18,7 @@ class SVGFEGaussianBlur extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEImage.php
+++ b/src/Nodes/Filters/SVGFEImage.php
@@ -18,9 +18,7 @@ class SVGFEImage extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEMerge.php
+++ b/src/Nodes/Filters/SVGFEMerge.php
@@ -18,9 +18,7 @@ class SVGFEMerge extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEMergeNode.php
+++ b/src/Nodes/Filters/SVGFEMergeNode.php
@@ -18,9 +18,7 @@ class SVGFEMergeNode extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEMorphology.php
+++ b/src/Nodes/Filters/SVGFEMorphology.php
@@ -18,9 +18,7 @@ class SVGFEMorphology extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEOffset.php
+++ b/src/Nodes/Filters/SVGFEOffset.php
@@ -18,9 +18,7 @@ class SVGFEOffset extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFEPointLight.php
+++ b/src/Nodes/Filters/SVGFEPointLight.php
@@ -18,9 +18,7 @@ class SVGFEPointLight extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFESpecularLighting.php
+++ b/src/Nodes/Filters/SVGFESpecularLighting.php
@@ -18,9 +18,7 @@ class SVGFESpecularLighting extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFESpotLight.php
+++ b/src/Nodes/Filters/SVGFESpotLight.php
@@ -18,9 +18,7 @@ class SVGFESpotLight extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFETile.php
+++ b/src/Nodes/Filters/SVGFETile.php
@@ -18,9 +18,7 @@ class SVGFETile extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFETurbulence.php
+++ b/src/Nodes/Filters/SVGFETurbulence.php
@@ -18,9 +18,7 @@ class SVGFETurbulence extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Filters/SVGFilter.php
+++ b/src/Nodes/Filters/SVGFilter.php
@@ -18,9 +18,7 @@ class SVGFilter extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGAnimate.php
+++ b/src/Nodes/Presentation/SVGAnimate.php
@@ -18,9 +18,7 @@ class SVGAnimate extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGAnimateMotion.php
+++ b/src/Nodes/Presentation/SVGAnimateMotion.php
@@ -18,9 +18,7 @@ class SVGAnimateMotion extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGAnimateTransform.php
+++ b/src/Nodes/Presentation/SVGAnimateTransform.php
@@ -18,9 +18,7 @@ class SVGAnimateTransform extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGLinearGradient.php
+++ b/src/Nodes/Presentation/SVGLinearGradient.php
@@ -18,9 +18,7 @@ class SVGLinearGradient extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGMPath.php
+++ b/src/Nodes/Presentation/SVGMPath.php
@@ -18,9 +18,7 @@ class SVGMPath extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGRadialGradient.php
+++ b/src/Nodes/Presentation/SVGRadialGradient.php
@@ -18,9 +18,7 @@ class SVGRadialGradient extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGSet.php
+++ b/src/Nodes/Presentation/SVGSet.php
@@ -18,9 +18,7 @@ class SVGSet extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGStop.php
+++ b/src/Nodes/Presentation/SVGStop.php
@@ -18,9 +18,7 @@ class SVGStop extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Presentation/SVGView.php
+++ b/src/Nodes/Presentation/SVGView.php
@@ -18,9 +18,7 @@ class SVGView extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/SVGGenericNodeType.php
+++ b/src/Nodes/SVGGenericNodeType.php
@@ -19,11 +19,17 @@ class SVGGenericNodeType extends SVGNodeContainer
         $this->tagName = $tagName;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getName()
     {
         return $this->tagName;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         // do nothing

--- a/src/Nodes/SVGNodeContainer.php
+++ b/src/Nodes/SVGNodeContainer.php
@@ -155,7 +155,9 @@ abstract class SVGNodeContainer extends SVGNode
         return $this;
     }
 
-
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {
@@ -223,6 +225,9 @@ abstract class SVGNodeContainer extends SVGNode
         return preg_grep($pattern, array_keys($this->containerStyles));
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getElementsByTagName($tagName, array &$result = array())
     {
         foreach ($this->children as $child) {
@@ -235,6 +240,9 @@ abstract class SVGNodeContainer extends SVGNode
         return $result;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getElementsByClassName($className, array &$result = array())
     {
         if (!is_array($className)) {

--- a/src/Nodes/Shapes/SVGCircle.php
+++ b/src/Nodes/Shapes/SVGCircle.php
@@ -87,6 +87,9 @@ class SVGCircle extends SVGNodeContainer
         return $this->setAttribute('r', $r);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {

--- a/src/Nodes/Shapes/SVGEllipse.php
+++ b/src/Nodes/Shapes/SVGEllipse.php
@@ -109,6 +109,9 @@ class SVGEllipse extends SVGNodeContainer
         return $this->setAttribute('ry', $ry);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {

--- a/src/Nodes/Shapes/SVGLine.php
+++ b/src/Nodes/Shapes/SVGLine.php
@@ -109,6 +109,9 @@ class SVGLine extends SVGNodeContainer
         return $this->setAttribute('y2', $y2);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -42,6 +42,9 @@ class SVGPath extends SVGNodeContainer
         return $this->setAttribute('d', $d);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {

--- a/src/Nodes/Shapes/SVGPolygon.php
+++ b/src/Nodes/Shapes/SVGPolygon.php
@@ -20,6 +20,9 @@ class SVGPolygon extends SVGPolygonalShape
         parent::__construct($points);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {

--- a/src/Nodes/Shapes/SVGPolygonalShape.php
+++ b/src/Nodes/Shapes/SVGPolygonalShape.php
@@ -23,6 +23,9 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
         $this->points = $points;
     }
 
+    /**
+     * @inheritdoc
+     */
     public static function constructFromAttributes($attrs)
     {
         $points = array();
@@ -112,6 +115,9 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
         return $this;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getSerializableAttributes()
     {
         $attrs = parent::getSerializableAttributes();

--- a/src/Nodes/Shapes/SVGPolyline.php
+++ b/src/Nodes/Shapes/SVGPolyline.php
@@ -20,6 +20,9 @@ class SVGPolyline extends SVGPolygonalShape
         parent::__construct($points);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -145,6 +145,9 @@ class SVGRect extends SVGNodeContainer
         return $this->setAttribute('ry', $ry);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if ($this->getComputedStyle('display') === 'none') {

--- a/src/Nodes/Structures/SVGClipPath.php
+++ b/src/Nodes/Structures/SVGClipPath.php
@@ -20,9 +20,7 @@ class SVGClipPath extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGDefs.php
+++ b/src/Nodes/Structures/SVGDefs.php
@@ -18,9 +18,7 @@ class SVGDefs extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -82,6 +82,9 @@ class SVGDocumentFragment extends SVGNodeContainer
         return $this->setAttribute('height', $height);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getComputedStyle($name)
     {
         // return either explicit declarations ...
@@ -95,11 +98,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     }
 
     /**
-     * Draws this node to the given rasterizer.
-     *
-     * @param SVGRasterizer $rasterizer The rasterizer to draw to.
-     *
-     * @return void
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {
@@ -133,6 +132,9 @@ class SVGDocumentFragment extends SVGNodeContainer
         imagedestroy($img);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getSerializableAttributes()
     {
         $attrs = parent::getSerializableAttributes();
@@ -147,6 +149,9 @@ class SVGDocumentFragment extends SVGNodeContainer
         return $attrs;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getSerializableNamespaces()
     {
         if ($this->isRoot()) {

--- a/src/Nodes/Structures/SVGMarker.php
+++ b/src/Nodes/Structures/SVGMarker.php
@@ -18,9 +18,7 @@ class SVGMarker extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGMask.php
+++ b/src/Nodes/Structures/SVGMask.php
@@ -18,9 +18,7 @@ class SVGMask extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGMetadata.php
+++ b/src/Nodes/Structures/SVGMetadata.php
@@ -18,9 +18,7 @@ class SVGMetadata extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGPattern.php
+++ b/src/Nodes/Structures/SVGPattern.php
@@ -18,9 +18,7 @@ class SVGPattern extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGScript.php
+++ b/src/Nodes/Structures/SVGScript.php
@@ -24,6 +24,9 @@ class SVGScript extends SVGNodeContainer
         $this->content = $content;
     }
 
+    /**
+     * @inheritdoc
+     */
     public static function constructFromAttributes($attr)
     {
         $cdata = trim(preg_replace('/^\s*\/\/<!\[CDATA\[([\s\S]*)\/\/\]\]>\s*\z/', '$1', $attr));
@@ -54,9 +57,7 @@ class SVGScript extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGStyle.php
+++ b/src/Nodes/Structures/SVGStyle.php
@@ -27,6 +27,9 @@ class SVGStyle extends SVGNodeContainer
         $this->setAttribute('type', $type);
     }
 
+    /**
+     * @inheritdoc
+     */
     public static function constructFromAttributes($attr)
     {
         $cdata = trim(preg_replace('/^\s*\/\/<!\[CDATA\[([\s\S]*)\/\/\]\]>\s*\z/', '$1', $attr));
@@ -75,9 +78,7 @@ class SVGStyle extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGSwitch.php
+++ b/src/Nodes/Structures/SVGSwitch.php
@@ -18,9 +18,7 @@ class SVGSwitch extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGSymbol.php
+++ b/src/Nodes/Structures/SVGSymbol.php
@@ -18,9 +18,7 @@ class SVGSymbol extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Structures/SVGUse.php
+++ b/src/Nodes/Structures/SVGUse.php
@@ -18,9 +18,7 @@ class SVGUse extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Texts/SVGDesc.php
+++ b/src/Nodes/Texts/SVGDesc.php
@@ -18,9 +18,7 @@ class SVGDesc extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Texts/SVGTSpan.php
+++ b/src/Nodes/Texts/SVGTSpan.php
@@ -18,9 +18,7 @@ class SVGTSpan extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Texts/SVGText.php
+++ b/src/Nodes/Texts/SVGText.php
@@ -67,6 +67,9 @@ class SVGText extends SVGNodeContainer
         return $this;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getComputedStyle($name)
     {
         // force stroke before fill
@@ -78,6 +81,9 @@ class SVGText extends SVGNodeContainer
         return parent::getComputedStyle($name);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function rasterize(SVGRasterizer $rasterizer)
     {
         if (empty($this->font)) {

--- a/src/Nodes/Texts/SVGTextPath.php
+++ b/src/Nodes/Texts/SVGTextPath.php
@@ -17,9 +17,7 @@ class SVGTextPath extends SVGNodeContainer
     }
 
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
-     * @param SVGRasterizer $rasterizer
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Nodes/Texts/SVGTitle.php
+++ b/src/Nodes/Texts/SVGTitle.php
@@ -20,9 +20,7 @@ class SVGTitle extends SVGNodeContainer
     /**
      * Dummy implementation
      *
-     * @param SVGRasterizer $rasterizer
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {

--- a/src/Rasterization/Renderers/EllipseRenderer.php
+++ b/src/Rasterization/Renderers/EllipseRenderer.php
@@ -15,6 +15,9 @@ use SVG\Rasterization\SVGRasterizer;
  */
 class EllipseRenderer extends MultiPassRenderer
 {
+    /**
+     * @inheritdoc
+     */
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
         return array(
@@ -25,11 +28,17 @@ class EllipseRenderer extends MultiPassRenderer
         );
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderFill($image, array $params, $color)
     {
         imagefilledellipse($image, $params['cx'], $params['cy'], $params['width'], $params['height'], $color);
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
         imagesetthickness($image, $strokeWidth);

--- a/src/Rasterization/Renderers/LineRenderer.php
+++ b/src/Rasterization/Renderers/LineRenderer.php
@@ -15,6 +15,9 @@ use SVG\Rasterization\SVGRasterizer;
  */
 class LineRenderer extends MultiPassRenderer
 {
+    /**
+     * @inheritdoc
+     */
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
         $offsetX = $rasterizer->getOffsetX();
@@ -29,13 +32,16 @@ class LineRenderer extends MultiPassRenderer
     }
 
     /**
-     * @SuppressWarnings("unused")
+     * @inheritdoc
      */
     protected function renderFill($image, array $params, $color)
     {
         // can't fill
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
         imagesetthickness($image, $strokeWidth);

--- a/src/Rasterization/Renderers/PolygonRenderer.php
+++ b/src/Rasterization/Renderers/PolygonRenderer.php
@@ -14,6 +14,9 @@ use SVG\Rasterization\SVGRasterizer;
  */
 class PolygonRenderer extends MultiPassRenderer
 {
+    /**
+     * @inheritdoc
+     */
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
         $scaleX = $rasterizer->getScaleX();
@@ -35,6 +38,9 @@ class PolygonRenderer extends MultiPassRenderer
         );
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderFill($image, array $params, $color)
     {
         if ($params['numpoints'] < 3) {
@@ -46,6 +52,9 @@ class PolygonRenderer extends MultiPassRenderer
         imagefilledpolygon($image, $params['points'], $params['numpoints'], $color);
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
         imagesetthickness($image, $strokeWidth);

--- a/src/Rasterization/Renderers/RectRenderer.php
+++ b/src/Rasterization/Renderers/RectRenderer.php
@@ -17,6 +17,9 @@ use SVG\Rasterization\SVGRasterizer;
  */
 class RectRenderer extends MultiPassRenderer
 {
+    /**
+     * @inheritdoc
+     */
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
         $w  = self::prepareLengthX($options['width'], $rasterizer);
@@ -60,6 +63,9 @@ class RectRenderer extends MultiPassRenderer
         );
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderFill($image, array $params, $color)
     {
         if ($params['empty']) {
@@ -119,6 +125,9 @@ class RectRenderer extends MultiPassRenderer
         imagedestroy($corners);
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
         if ($params['empty']) {

--- a/src/Rasterization/Renderers/TextRenderer.php
+++ b/src/Rasterization/Renderers/TextRenderer.php
@@ -5,6 +5,9 @@ use SVG\Rasterization\SVGRasterizer;
 
 class TextRenderer extends MultiPassRenderer
 {
+    /**
+     * @inheritdoc
+     */
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
         return array(
@@ -16,6 +19,9 @@ class TextRenderer extends MultiPassRenderer
         );
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderFill($image, array $params, $color)
     {
         imagettftext(
@@ -30,6 +36,9 @@ class TextRenderer extends MultiPassRenderer
         );
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
         $x = $params['x'];

--- a/tests/Nodes/SVGNodeTest.php
+++ b/tests/Nodes/SVGNodeTest.php
@@ -9,7 +9,7 @@ class SVGNodeSubclass extends SVGNode
     const TAG_NAME = 'test_subclass';
 
     /**
-     * @SuppressWarnings("unused")
+     * @inheritdoc
      */
     public function rasterize(\SVG\Rasterization\SVGRasterizer $rasterizer)
     {

--- a/tests/Rasterization/Renderers/ImageRendererTest.php
+++ b/tests/Rasterization/Renderers/ImageRendererTest.php
@@ -10,7 +10,7 @@ class SVGNodeClass extends SVGNode
     const TAG_NAME = 'test_subclass';
 
     /**
-     * @SuppressWarnings("unused")
+     * @inheritdoc
      */
     public function rasterize(\SVG\Rasterization\SVGRasterizer $rasterizer)
     {


### PR DESCRIPTION
This helps with two things:

1. PHPMD is satisfied about unused formal parameters (an unfortunate workaround).
2. It makes it clearer which methods are actually inherited (arguably useful, but also adds to the noise).