### PR TITLE
Prefix Travis install with travis_retry (fixes #94)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ jobs:
     after_script:
     - ./cc-test-reporter after-build -t clover --exit-code $TRAVIS_TEST_RESULT
 
-install: composer install --no-interaction
+install: travis_retry composer install --no-interaction
 
 script: vendor/bin/phpunit


### PR DESCRIPTION
See #94. This is not a foolproof solution, as failure is random with chance 0.X and this simply reduces it to (0.X)^3. It should be good enough in most cases though.