### PR TITLE
Add converter for unitless lengths during read

### DIFF
--- a/src/Reading/AttributeConverter.php
+++ b/src/Reading/AttributeConverter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SVG\Reading;
+
+/**
+ * Base interface for SVG presentation attribute => CSS property converters.
+ */
+interface AttributeConverter
+{
+    /**
+     * Convert the given attribute value into a valid CSS property value.
+     *
+     * @param string $value The attribute.
+     *
+     * @return string The converted value that can be used in CSS.
+     */
+    public function convert($value);
+}

--- a/src/Reading/LengthAttributeConverter.php
+++ b/src/Reading/LengthAttributeConverter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SVG\Reading;
+
+/**
+ * This converter detects unitless lengths and converts them to qualified
+ * lengths by appending 'px' (e.g. '42' => '42px').
+ *
+ * This is required because SVG allows unitless presentation attributes, but not
+ * unitless CSS properties
+ * (e.g. `font-size="11"` is valid, but `style="font-size: 11"` is not).
+ */
+class LengthAttributeConverter implements AttributeConverter
+{
+    private static $instance;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Obtain the instance of this class.
+     *
+     * @return self The singleton instance.
+     */
+    public static function getInstance()
+    {
+        if (empty(self::$instance)) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function convert($value)
+    {
+        if (preg_match('/^\s*([+-]?(?:\d+\.?|\d*\.?\d+))\s*$/', $value, $matches)) {
+            return $matches[1] . 'px';
+        }
+        return $value;
+    }
+}

--- a/tests/Reading/LengthAttributeConverterTest.php
+++ b/tests/Reading/LengthAttributeConverterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SVG;
+
+use SVG\Reading\LengthAttributeConverter;
+
+/**
+ * @SuppressWarnings(PHPMD)
+ */
+class LengthAttributeConverterTest extends \PHPUnit\Framework\TestCase
+{
+    public function testShouldQualifyUnitlessNumbers()
+    {
+        $this->assertSame('42px', LengthAttributeConverter::getInstance()->convert('42'));
+        $this->assertSame('+42px', LengthAttributeConverter::getInstance()->convert('+42'));
+        $this->assertSame('-42px', LengthAttributeConverter::getInstance()->convert('-42'));
+        $this->assertSame('42.123px', LengthAttributeConverter::getInstance()->convert('42.123'));
+        $this->assertSame('-.123px', LengthAttributeConverter::getInstance()->convert('-.123'));
+        $this->assertSame('-42.px', LengthAttributeConverter::getInstance()->convert('-42.'));
+        $this->assertSame('-42.123px', LengthAttributeConverter::getInstance()->convert('-42.123'));
+    }
+
+    public function testShouldTrimWhitespace()
+    {
+        $this->assertSame('-42.123px', LengthAttributeConverter::getInstance()->convert('  -42.123'));
+        $this->assertSame('-42.123px', LengthAttributeConverter::getInstance()->convert('-42.123  '));
+        $this->assertSame('-42.123px', LengthAttributeConverter::getInstance()->convert(" \n -42.123 \n "));
+    }
+
+    public function testShouldIgnoreOtherValues()
+    {
+        $this->assertSame('42%', LengthAttributeConverter::getInstance()->convert('42%'));
+        $this->assertSame('42px', LengthAttributeConverter::getInstance()->convert('42px'));
+        $this->assertSame('none', LengthAttributeConverter::getInstance()->convert('none'));
+        $this->assertSame('42 37', LengthAttributeConverter::getInstance()->convert('42 37'));
+    }
+}

--- a/tests/Reading/SVGReaderTest.php
+++ b/tests/Reading/SVGReaderTest.php
@@ -144,6 +144,22 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('#AABBCC', $rect->getStyle('stroke'));
     }
 
+    public function testShouldConvertUnitlessCSSLengths()
+    {
+        $code  = '<svg xmlns="http://www.w3.org/2000/svg">';
+        $code .= '<text font-size="11" letter-spacing="2" word-spacing="3">foo</text>';
+        $code .= '</svg>';
+
+        $svgReader = new SVGReader();
+        $result = $svgReader->parseString($code);
+
+        $text = $result->getDocument()->getChild(0);
+
+        $this->assertSame('11px', $text->getStyle('font-size'));
+        $this->assertSame('2px', $text->getStyle('letter-spacing'));
+        $this->assertSame('3px', $text->getStyle('word-spacing'));
+    }
+
     public function testShouldRecursivelyAddChildren()
     {
         // should recursively add all child nodes


### PR DESCRIPTION
Fixes #96 

**Background info:**

SVG allows some presentation attributes, for example `font-size`, to be specified without a unit; like this:

```xml
<text font-size="11">foo</text>
```

The same would not be valid in CSS, where a unit is required; like this:

```xml
<text style="font-size: 11px">foo</text>
```

**Reason for this PR:**

PHP-SVG merges attributes and style properties during reading. In that process, once valid attributes can become invalid CSS properties. This PR fixes that by adding value conversion facilities.