### PR TITLE
Make SVG dimension parameters optional

### DIFF
--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -23,8 +23,8 @@ class SVGDocumentFragment extends SVGNodeContainer
     );
 
     /**
-     * @param string|null $width      The declared width.
-     * @param string|null $height     The declared height.
+     * @param string|null $width  The declared width.
+     * @param string|null $height The declared height.
      */
     public function __construct($width = null, $height = null)
     {

--- a/src/Reading/SVGReader.php
+++ b/src/Reading/SVGReader.php
@@ -63,10 +63,7 @@ class SVGReader
             return null;
         }
 
-        $width = isset($xml['width']) ? $xml['width'] : null;
-        $height = isset($xml['height']) ? $xml['height'] : null;
-
-        $img = new SVG($width, $height);
+        $img = new SVG();
         $doc = $img->getDocument();
 
         $namespaces = $xml->getNamespaces(true);

--- a/src/SVG.php
+++ b/src/SVG.php
@@ -20,10 +20,10 @@ class SVG
     private $document;
 
     /**
-     * @param string   $width      The image's width (any CSS length).
-     * @param string   $height     The image's height (any CSS length).
+     * @param string|null $width    The image's width (any CSS length).
+     * @param string|null $height   The image's height (any CSS length).
      */
-    public function __construct($width, $height)
+    public function __construct($width = null, $height = null)
     {
         $this->document = new SVGDocumentFragment($width, $height);
     }

--- a/tests/SVGTest.php
+++ b/tests/SVGTest.php
@@ -28,7 +28,7 @@ class SVGTest extends \PHPUnit\Framework\TestCase
 
     public function testGetDocument()
     {
-        $image = new SVG(37, 42);
+        $image = new SVG();
         $doc = $image->getDocument();
 
         // should be instanceof the correct class
@@ -37,8 +37,17 @@ class SVGTest extends \PHPUnit\Framework\TestCase
 
         // should be set to root
         $this->assertTrue($doc->isRoot());
+    }
 
-        // should have correct width and height
+    public function testConstructSetsDocumentDimensions()
+    {
+        $image = new SVG();
+        $doc = $image->getDocument();
+        $this->assertNull($doc->getWidth());
+        $this->assertNull($doc->getHeight());
+
+        $image = new SVG(37, 42);
+        $doc = $image->getDocument();
         $this->assertSame('37', $doc->getWidth());
         $this->assertSame('42', $doc->getHeight());
     }


### PR DESCRIPTION
Sometimes, it might be required to create an SVG with no width/height. The width/height arguments of `SVGDocumentFragment` are already optional. This PR is making them optional for `SVG` too. Note that not providing dimensions potentially hinders rasterization.