### PR TITLE
Make SVGPolygonalShape points dynamic

### DIFF
--- a/src/Nodes/Shapes/SVGPolygonalShape.php
+++ b/src/Nodes/Shapes/SVGPolygonalShape.php
@@ -66,8 +66,8 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
     {
         $pointsAttribute = $this->getAttribute('points');
         if (isset($pointsAttribute)) {
-            $separatorCount = preg_match_all('/[\s,]+/', trim($pointsAttribute));
-            return (int) (($separatorCount + 1) / 2);
+            $coords = self::splitCoordinates($pointsAttribute);
+            return (int) (count($coords) / 2);
         }
         return 0;
     }
@@ -106,7 +106,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setPoint($index, $point)
+    public function setPoint($index, array $point)
     {
         $coords = self::splitCoordinates($this->getAttribute('points') ?: '');
         $coords[$index * 2] = $point[0];
@@ -121,7 +121,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
         return preg_split('/[\s,]+/', trim($pointsString));
     }
 
-    private static function joinCoordinates($coordinatesArray)
+    private static function joinCoordinates(array $coordinatesArray)
     {
         $pointsString = '';
         for ($i = 0, $n = count($coordinatesArray); $i < $n; ++$i) {
@@ -150,12 +150,11 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
     private static function joinPoints(array $pointsArray)
     {
         $pointsString = '';
-        for ($i = 0, $n = count($pointsArray); $i < $n; ++$i) {
-            $point = $pointsArray[$i];
+        foreach ($pointsArray as $point) {
             if (count($point) < 2) {
                 break;
             }
-            if ($i > 0) {
+            if ($pointsString !== '') {
                 $pointsString .= ' ';
             }
             $pointsString .= $point[0] . ',' . $point[1];

--- a/src/Nodes/Shapes/SVGPolygonalShape.php
+++ b/src/Nodes/Shapes/SVGPolygonalShape.php
@@ -130,6 +130,9 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
 
         for ($i = 0, $n = count($pointsArray); $i < $n; ++$i) {
             $point = $pointsArray[$i];
+            if (count($point) < 2) {
+                break;
+            }
             if ($i > 0) {
                 $pointsString .= ' ';
             }

--- a/tests/Nodes/Shapes/SVGPolygonTest.php
+++ b/tests/Nodes/Shapes/SVGPolygonTest.php
@@ -21,7 +21,7 @@ class SVGPolygonTest extends \PHPUnit\Framework\TestCase
             array(37, 37),
         );
         $obj = new SVGPolygon($points);
-        $this->assertSame($points, $obj->getPoints());
+        $this->assertEquals($points, $obj->getPoints());
     }
 
     public function testRasterize()
@@ -40,7 +40,7 @@ class SVGPolygonTest extends \PHPUnit\Framework\TestCase
         // should call image renderer with correct options
         $rast->expects($this->once())->method('render')->with(
             $this->identicalTo('polygon'),
-            $this->identicalTo(array(
+            $this->equalTo(array(
                 'open' => false,
                 'points' => $points,
             )),

--- a/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
+++ b/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
@@ -11,7 +11,7 @@ class SVGPolygonalShapeSubclass extends SVGPolygonalShape
 {
     const TAG_NAME = 'test_subclass';
 
-    public function __construct($points)
+    public function __construct(array $points = null)
     {
         parent::__construct($points);
     }
@@ -34,19 +34,17 @@ class SVGPolygonalShapeTest extends \PHPUnit\Framework\TestCase
             array(37, 37),
         );
         $obj = new SVGPolygonalShapeSubclass($points);
-        $this->assertSame($points, $obj->getPoints());
+        $this->assertEquals($points, $obj->getPoints());
     }
 
-    public function testConstructFromAttributes()
+    public function testSetAttributePoints()
     {
         // should set empty points by default
-        $obj = SVGPolygonalShapeSubclass::constructFromAttributes(array());
+        $obj = new SVGPolygonalShapeSubclass();
         $this->assertSame(0, $obj->countPoints());
 
         // should set points when provided
-        $obj = SVGPolygonalShapeSubclass::constructFromAttributes(array(
-            'points' => '1,1 2,2 3,3',
-        ));
+        $obj->setAttribute('points', '1,1 2,2 3,3');
         $this->assertSame(3, $obj->countPoints());
     }
 
@@ -56,13 +54,13 @@ class SVGPolygonalShapeTest extends \PHPUnit\Framework\TestCase
 
         // should support 2 floats
         $obj->addPoint(42.5, 42.5);
-        $this->assertSame(array(
+        $this->assertEquals(array(
             array(42.5, 42.5),
         ), $obj->getPoints());
 
         // should support an array
         $obj->addPoint(array(37, 37));
-        $this->assertSame(array(
+        $this->assertEquals(array(
             array(42.5, 42.5),
             array(37, 37),
         ), $obj->getPoints());
@@ -80,7 +78,7 @@ class SVGPolygonalShapeTest extends \PHPUnit\Framework\TestCase
 
         // should remove points by index
         $obj->removePoint(0);
-        $this->assertSame(array(
+        $this->assertEquals(array(
             array(37, 37),
         ), $obj->getPoints());
 
@@ -99,7 +97,7 @@ class SVGPolygonalShapeTest extends \PHPUnit\Framework\TestCase
 
         // should replace the point at the given index
         $obj->setPoint(1, array(100, 100));
-        $this->assertSame(array(
+        $this->assertEquals(array(
             array(42.5, 42.5),
             array(100, 100),
         ), $obj->getPoints());

--- a/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
+++ b/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
@@ -49,6 +49,14 @@ class SVGPolygonalShapeTest extends \PHPUnit\Framework\TestCase
         );
         $obj = new SVGPolygonalShapeSubclass($points);
         $this->assertSame('42.5,42.5 37,37', $obj->getAttribute('points'));
+
+        // should stop when invalid point is encountered
+        $obj = new SVGPolygonalShapeSubclass(array(
+            array(1, 2),
+            array(3),
+            array(4, 5),
+        ));
+        $this->assertSame('1,2', $obj->getAttribute('points'));
     }
 
     /**

--- a/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
+++ b/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
@@ -142,6 +142,14 @@ class SVGPolygonalShapeTest extends \PHPUnit\Framework\TestCase
         // should use attribute as source
         $obj->setAttribute('points', '1,2 3,4 5,6');
         $this->assertSame(3, $obj->countPoints());
+
+        // should support a variety of separators
+        $obj->setAttribute('points', '1,-2 3 -4  ,  5   -6  ,7,-8');
+        $this->assertSame(4, $obj->countPoints());
+
+        // can deal with an odd number of coordinates
+        $obj->setAttribute('points', '1 2 3 4 5 6 7');
+        $this->assertSame(3, $obj->countPoints());
     }
 
     /**

--- a/tests/Nodes/Shapes/SVGPolylineTest.php
+++ b/tests/Nodes/Shapes/SVGPolylineTest.php
@@ -21,7 +21,7 @@ class SVGPolylineTest extends \PHPUnit\Framework\TestCase
             array(37, 37),
         );
         $obj = new SVGPolyline($points);
-        $this->assertSame($points, $obj->getPoints());
+        $this->assertEquals($points, $obj->getPoints());
     }
 
     public function testRasterize()
@@ -40,7 +40,7 @@ class SVGPolylineTest extends \PHPUnit\Framework\TestCase
         // should call image renderer with correct options
         $rast->expects($this->once())->method('render')->with(
             $this->identicalTo('polygon'),
-            $this->identicalTo(array(
+            $this->equalTo(array(
                 'open' => true,
                 'points' => $points,
             )),


### PR DESCRIPTION
This PR serves to remove the need for `constructFromAttributes` on `SVGPolygonalShape`. It replaces the separate `$points` property with code that dynamically accesses the `points` attribute. This should also help with eliminating pitfalls such as property and attribute getting out of sync.