### PR TITLE
Eliminate constructFromAttributes

### DIFF
--- a/src/Nodes/CDataContainer.php
+++ b/src/Nodes/CDataContainer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SVG\Nodes;
+
+/**
+ * Marker interface for style, script etc. nodes that have CDATA values.
+ */
+interface CDataContainer
+{
+}

--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -30,24 +30,6 @@ abstract class SVGNode
     }
 
     /**
-     * Factory function for this class, which accepts an associative array of
-     * strings instead of parameters in the correct order (like `__construct`).
-     *
-     * By default, simply invokes the constructor with no arguments. Subclasses
-     * may choose to override this if they require special behavior.
-     *
-     * @param string[] $attrs The attribute array (or array-like object; e.g. \SimpleXMLElement).
-     *
-     * @return static A new instance of the class this was called on.
-     *
-     * @SuppressWarnings("unused")
-     */
-    public static function constructFromAttributes($attrs)
-    {
-        return new static();
-    }
-
-    /**
      * @return string This node's tag name (e.g. 'rect' or 'g').
      */
     public function getName()

--- a/src/Nodes/SVGNodeContainer.php
+++ b/src/Nodes/SVGNodeContainer.php
@@ -149,7 +149,7 @@ abstract class SVGNodeContainer extends SVGNode
      */
     public function addContainerStyle(SVGStyle $styleNode)
     {
-        $newStyles = SVGStyleParser::parseCss($styleNode->getCss());
+        $newStyles = SVGStyleParser::parseCss($styleNode->getValue());
         $this->containerStyles = array_merge($this->containerStyles, $newStyles);
 
         return $this;

--- a/src/Nodes/Structures/SVGScript.php
+++ b/src/Nodes/Structures/SVGScript.php
@@ -2,17 +2,16 @@
 
 namespace SVG\Nodes\Structures;
 
+use SVG\Nodes\CDataContainer;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
 
 /**
  * Represents the SVG tag 'script'.
  */
-class SVGScript extends SVGNodeContainer
+class SVGScript extends SVGNodeContainer implements CDataContainer
 {
     const TAG_NAME = 'script';
-
-    private $content = '';
 
     /**
      * @param string $content The script content.
@@ -21,39 +20,7 @@ class SVGScript extends SVGNodeContainer
     {
         parent::__construct();
 
-        $this->content = $content;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public static function constructFromAttributes($attr)
-    {
-        $cdata = trim(preg_replace('/^\s*\/\/<!\[CDATA\[([\s\S]*)\/\/\]\]>\s*\z/', '$1', $attr));
-
-        return new static($cdata);
-    }
-
-    /**
-     * @return string The script content.
-     */
-    public function getScript()
-    {
-        return $this->content;
-    }
-
-    /**
-     * Sets the script content.
-     *
-     * @param $content string The new cdata content
-     *
-     * @return $this The node instance for call chaining
-     */
-    public function setScript($content)
-    {
-        $this->content = $content;
-
-        return $this;
+        $this->setValue($content);
     }
 
     /**
@@ -61,6 +28,5 @@ class SVGScript extends SVGNodeContainer
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {
-        // Nothing to rasterize.
     }
 }

--- a/src/Nodes/Structures/SVGStyle.php
+++ b/src/Nodes/Structures/SVGStyle.php
@@ -2,6 +2,7 @@
 
 namespace SVG\Nodes\Structures;
 
+use SVG\Nodes\CDataContainer;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
 
@@ -9,32 +10,20 @@ use SVG\Rasterization\SVGRasterizer;
  * Represents the SVG tag 'style'.
  * Has the attribute 'type' and the CSS content.
  */
-class SVGStyle extends SVGNodeContainer
+class SVGStyle extends SVGNodeContainer implements CDataContainer
 {
     const TAG_NAME = 'style';
 
-    private $css = '';
-
     /**
-     * @param string $css The CSS data rules.
-     * @param string $type The style type attribute.
+     * @param string $css   The CSS data rules.
+     * @param string $type  The style type attribute.
      */
     public function __construct($css = '', $type = 'text/css')
     {
         parent::__construct();
 
-        $this->css = $css;
-        $this->setAttribute('type', $type);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public static function constructFromAttributes($attr)
-    {
-        $cdata = trim(preg_replace('/^\s*\/\/<!\[CDATA\[([\s\S]*)\/\/\]\]>\s*\z/', '$1', $attr));
-
-        return new static($cdata);
+        $this->setValue($css);
+        $this->setType($type);
     }
 
     /**
@@ -56,33 +45,9 @@ class SVGStyle extends SVGNodeContainer
     }
 
     /**
-     * @return string The CSS content.
-     */
-    public function getCss()
-    {
-        return $this->css;
-    }
-
-    /**
-     * Sets the CSS content.
-     *
-     * @param $css string The new cdata content
-     *
-     * @return $this The node instance for call chaining
-     */
-    public function setCss($css)
-    {
-        $this->css = $css;
-
-        return $this;
-    }
-
-    /**
      * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer)
     {
-        // Nothing to rasterize.
-        // All properties passed through container's global styles.
     }
 }

--- a/src/Reading/NodeRegistry.php
+++ b/src/Reading/NodeRegistry.php
@@ -103,8 +103,8 @@ class NodeRegistry
         $type = $xml->getName();
 
         if (isset(self::$nodeTypes[$type])) {
-            $call = array(self::$nodeTypes[$type], 'constructFromAttributes');
-            return call_user_func($call, $xml);
+            $nodeClass = self::$nodeTypes[$type];
+            return new $nodeClass();
         }
 
         return new SVGGenericNodeType($type);

--- a/src/Writing/SVGWriter.php
+++ b/src/Writing/SVGWriter.php
@@ -4,8 +4,7 @@ namespace SVG\Writing;
 
 use SVG\Nodes\SVGNode;
 use SVG\Nodes\SVGNodeContainer;
-use SVG\Nodes\Structures\SVGStyle;
-use SVG\Nodes\Structures\SVGScript;
+use SVG\Nodes\CDataContainer;
 
 /**
  * This class is used for composing ("writing") XML strings from nodes.
@@ -55,16 +54,10 @@ class SVGWriter
 
         $textContent = htmlspecialchars($node->getValue());
 
-        if ($node instanceof SVGStyle) {
+        if ($node instanceof CDataContainer) {
             $this->outString .= '>';
-            $this->writeCdata($node->getCss());
-            $this->outString .= $textContent . '</' . $node->getName() . '>';
-            return;
-        }
-        if ($node instanceof SVGScript) {
-            $this->outString .= '>';
-            $this->writeCdata($node->getContent());
-            $this->outString .= $textContent . '</' . $node->getName() . '>';
+            $this->writeCdata($node->getValue());
+            $this->outString .= '</' . $node->getName() . '>';
             return;
         }
 
@@ -193,10 +186,6 @@ class SVGWriter
      */
     private function writeCdata($cdata)
     {
-        $xml1 = defined('ENT_XML1') ? ENT_XML1 : 16;
-
-        $cdata = htmlspecialchars($cdata, $xml1 | ENT_COMPAT);
-
         $this->outString .= '<![CDATA[' . $cdata . ']]>';
     }
 }

--- a/tests/Nodes/SVGNodeContainerTest.php
+++ b/tests/Nodes/SVGNodeContainerTest.php
@@ -3,7 +3,6 @@
 namespace SVG;
 
 use SVG\Nodes\SVGNodeContainer;
-use SVG\Utilities\SVGStyleParser;
 
 class SVGNodeContainerSubclass extends SVGNodeContainer
 {
@@ -232,20 +231,6 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(
             $root_1_0_0, $root_1_1,
         ), $obj->getElementsByClassName(array('foo', 'bar')));
-    }
-
-    public function testParseCssWithMatchedElement()
-    {
-        $result = SVGStyleParser::parseCss('svg {background-color: beige;}');
-
-        $this->assertSame('beige', $result['svg']['background-color']);
-    }
-
-    public function testParseCssWithSkippedElement()
-    {
-        $result = SVGStyleParser::parseCss('@font-face {font-family: "Bitstream Vera Serif Bold";}');
-
-        $this->assertCount(0, $result);
     }
 
     public function testGetContainerStyleForNode()

--- a/tests/Nodes/SVGNodeTest.php
+++ b/tests/Nodes/SVGNodeTest.php
@@ -21,14 +21,6 @@ class SVGNodeSubclass extends SVGNode
  */
 class SVGNodeTest extends \PHPUnit\Framework\TestCase
 {
-    public function testConstructFromAttributes()
-    {
-        $obj = SVGNodeSubclass::constructFromAttributes(array());
-
-        // should construct child class
-        $this->assertInstanceOf('SVG\SVGNodeSubclass', $obj);
-    }
-
     public function testGetName()
     {
         $obj = new SVGNodeSubclass();

--- a/tests/Nodes/Structures/SVGScriptTest.php
+++ b/tests/Nodes/Structures/SVGScriptTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SVG;
+
+use SVG\Nodes\Structures\SVGScript;
+
+/**
+ * @coversDefaultClass \SVG\Nodes\Structures\SVGScript
+ *
+ * @SuppressWarnings(PHPMD)
+ */
+class SVGScriptTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @covers ::__construct
+     */
+    public function test__construct()
+    {
+        // should default to empty CSS, type = text/css
+        $obj = new SVGScript();
+        $this->assertSame('', $obj->getValue());
+
+        // should allow setting CSS and type
+        $obj = new SVGScript('alert()');
+        $this->assertSame('alert()', $obj->getValue());
+    }
+
+    /**
+     * @covers ::rasterize
+     */
+    public function testRasterize()
+    {
+        $obj = new SVGScript();
+
+        $rast = $this->getMockBuilder('\SVG\Rasterization\SVGRasterizer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // should not manipulate anything
+        $rast->expects($this->never())->method($this->anything());
+        $obj->rasterize($rast);
+    }
+}

--- a/tests/Nodes/Structures/SVGStyleTest.php
+++ b/tests/Nodes/Structures/SVGStyleTest.php
@@ -5,44 +5,65 @@ namespace SVG;
 use SVG\Nodes\Structures\SVGStyle;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Structures\SVGStyle
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGStyleTest extends \PHPUnit\Framework\TestCase
 {
-    public function testSetType()
+    /**
+     * @covers ::__construct
+     */
+    public function test__construct()
     {
+        // should default to empty CSS, type = text/css
         $obj = new SVGStyle();
+        $this->assertSame('', $obj->getValue());
+        $this->assertSame('text/css', $obj->getType());
 
-        $type = 'type_attribute';
-        $this->assertInstanceOf('SVG\Nodes\Structures\SVGStyle', $obj->setType($type));
-
-        $this->assertEquals($type, $obj->getAttribute('type'));
+        // should allow setting CSS and type
+        $obj = new SVGStyle('svg {background:beige;}', 'test-type');
+        $this->assertSame('svg {background:beige;}', $obj->getValue());
+        $this->assertSame('test-type', $obj->getType());
     }
 
+    /**
+     * @covers ::getType
+     */
     public function testGetType()
     {
         $obj = new SVGStyle();
+        $obj->setAttribute('type', 'test-type');
 
-        $type = 'type_attribute';
-        $obj->setAttribute('type', $type);
-
-        $this->assertSame($type, $obj->getType());
+        $this->assertSame('test-type', $obj->getType());
     }
 
-    public function testSetCss()
+    /**
+     * @covers ::setType
+     */
+    public function testSetType()
+    {
+        $obj = new SVGStyle();
+        $this->assertInstanceOf('SVG\Nodes\Structures\SVGStyle', $obj->setType('test-type'));
+
+        $this->assertEquals('test-type', $obj->getAttribute('type'));
+
+        $this->assertSame($obj, $obj->setType('foo'));
+    }
+
+    /**
+     * @covers ::rasterize
+     */
+    public function testRasterize()
     {
         $obj = new SVGStyle();
 
-        $this->assertInstanceOf('SVG\Nodes\Structures\SVGStyle', $obj->setCss('svg {background-color: beige;}'));
-    }
+        $rast = $this->getMockBuilder('\SVG\Rasterization\SVGRasterizer')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-    public function testGetCss()
-    {
-        $obj = new SVGStyle();
-
-        $css = 'svg {background-color: beige;}';
-        $obj->setCss($css);
-
-        $this->assertSame($css, $obj->getCss());
+        // should not manipulate anything
+        $rast->expects($this->never())->method($this->anything());
+        $obj->rasterize($rast);
     }
 }

--- a/tests/Reading/SVGReaderTest.php
+++ b/tests/Reading/SVGReaderTest.php
@@ -274,10 +274,24 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('&none', $doc->getChild(0)->getStyle('display'));
 
         // should decode entities in style body
-        $this->assertSame('" foo&bar>', $doc->getChild(0)->getCss());
+        $this->assertSame('" foo&bar>', $doc->getChild(0)->getValue());
 
         // should decode entities in value
         $this->assertSame('" foo&bar>', $doc->getChild(1)->getValue());
+    }
+
+    /**
+     * @covers SVG\Reading\SVGReader
+     */
+    public function testShouldRemoveCDataForStyles()
+    {
+        // should remove CDATA
+        $code  = '<svg xmlns="http://www.w3.org/2000/svg">';
+        $code .= '<style><![CDATA[g {display:none;}]]></style>';
+        $code .= '</svg>';
+        $result = (new SVGReader())->parseString($code);
+        $doc = $result->getDocument();
+        $this->assertSame('g {display:none;}', $doc->getChild(0)->getValue());
     }
 
     // the following requirement is due to SimpleXMLElement::getDocNamespaces

--- a/tests/Reading/SVGReaderTest.php
+++ b/tests/Reading/SVGReaderTest.php
@@ -289,7 +289,8 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $code  = '<svg xmlns="http://www.w3.org/2000/svg">';
         $code .= '<style><![CDATA[g {display:none;}]]></style>';
         $code .= '</svg>';
-        $result = (new SVGReader())->parseString($code);
+        $svgReader = new SVGReader();
+        $result = $svgReader->parseString($code);
         $doc = $result->getDocument();
         $this->assertSame('g {display:none;}', $doc->getChild(0)->getValue());
     }

--- a/tests/Reading/SVGReaderTest.php
+++ b/tests/Reading/SVGReaderTest.php
@@ -3,7 +3,6 @@
 namespace SVG;
 
 use SVG\Reading\SVGReader;
-use SVG\Utilities\SVGStyleParser;
 
 /**
  * @SuppressWarnings(PHPMD)
@@ -279,14 +278,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
 
         // should decode entities in value
         $this->assertSame('" foo&bar>', $doc->getChild(1)->getValue());
-    }
-
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
-    public function testParseStylesWithEmptyString()
-    {
-        $this->assertCount(0, SVGStyleParser::parseStyles(''));
     }
 
     // the following requirement is due to SimpleXMLElement::getDocNamespaces

--- a/tests/Utilities/SVGStyleParserTest.php
+++ b/tests/Utilities/SVGStyleParserTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SVG;
+
+use SVG\Utilities\SVGStyleParser;
+
+/**
+ * @SuppressWarnings(PHPMD)
+ */
+class SVGStyleParserTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @covers SVG\Utilities\SVGStyleParser
+     */
+    public function testParseStylesWithEmptyString()
+    {
+        $this->assertCount(0, SVGStyleParser::parseStyles(''));
+    }
+
+    /**
+     * @covers SVG\Utilities\SVGStyleParser
+     */
+    public function testParseCssWithMatchedElement()
+    {
+        $result = SVGStyleParser::parseCss('svg {background-color: beige;}');
+
+        $this->assertSame('beige', $result['svg']['background-color']);
+    }
+
+    /**
+     * @covers SVG\Utilities\SVGStyleParser
+     */
+    public function testParseCssWithSkippedElement()
+    {
+        $result = SVGStyleParser::parseCss('@font-face {font-family: "Bitstream Vera Serif Bold";}');
+
+        $this->assertCount(0, $result);
+    }
+}

--- a/tests/Writing/SVGWriterTest.php
+++ b/tests/Writing/SVGWriterTest.php
@@ -105,12 +105,19 @@ class SVGWriterTest extends \PHPUnit\Framework\TestCase
             'style="content: &quot; foo&amp;bar&gt;" />';
         $this->assertEquals($expect, $obj->getString());
 
-        // should encode entities in style body
+        // should encode entities in value
+        $obj = new SVGWriter();
+        $svgStyle = new \SVG\Nodes\Texts\SVGTitle('" foo&bar>');
+        $obj->writeNode($svgStyle);
+        $expect = $this->xmlDeclaration . '<title>&quot; foo&amp;bar&gt;</title>';
+        $this->assertEquals($expect, $obj->getString());
+
+        // should not encode entities in style body
         $obj = new SVGWriter();
         $svgStyle = new \SVG\Nodes\Structures\SVGStyle('" foo&bar>');
         $obj->writeNode($svgStyle);
         $expect = $this->xmlDeclaration . '<style type="text/css">' .
-            '<![CDATA[&quot; foo&amp;bar&gt;]]></style>';
+            '<![CDATA[" foo&bar>]]></style>';
         $this->assertEquals($expect, $obj->getString());
     }
 


### PR DESCRIPTION
* `constructFromAttributes` was used basically nowhere, a remnant of the past. All it did was cause confusion. This PR removes it entirely.
* Moreover, style and script CDATA handling is given an overhaul, which was required by (1).
* Last but not least, misplaced `SVGStyleParser` tests are moved to their own file.