### PR TITLE
Add covers annotation to all tests

### DIFF
--- a/tests/Nodes/Embedded/SVGImageTest.php
+++ b/tests/Nodes/Embedded/SVGImageTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Nodes\Embedded\SVGImage;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Embedded\SVGImage
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGImageTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should not set any attributes by default
@@ -26,6 +32,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::getHref
+     */
     public function testGetHref()
     {
         // should return xlink:href when available
@@ -44,6 +53,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($obj->getHref());
     }
 
+    /**
+     * @covers ::setHref
+     */
     public function testSetHref()
     {
         $obj = new SVGImage();
@@ -56,6 +68,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setHref('test-href'));
     }
 
+    /**
+     * @covers ::getX
+     */
     public function testGetX()
     {
         $obj = new SVGImage();
@@ -65,6 +80,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getX());
     }
 
+    /**
+     * @covers ::setX
+     */
     public function testSetX()
     {
         $obj = new SVGImage();
@@ -77,6 +95,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setX(42));
     }
 
+    /**
+     * @covers ::getY
+     */
     public function testGetY()
     {
         $obj = new SVGImage();
@@ -86,6 +107,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getY());
     }
 
+    /**
+     * @covers ::setY
+     */
     public function testSetY()
     {
         $obj = new SVGImage();
@@ -98,6 +122,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setY(42));
     }
 
+    /**
+     * @covers ::getWidth
+     */
     public function testGetWidth()
     {
         $obj = new SVGImage();
@@ -107,6 +134,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getWidth());
     }
 
+    /**
+     * @covers ::setWidth
+     */
     public function testSetWidth()
     {
         $obj = new SVGImage();
@@ -119,6 +149,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setWidth(42));
     }
 
+    /**
+     * @covers ::getHeight
+     */
     public function testGetHeight()
     {
         $obj = new SVGImage();
@@ -128,6 +161,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getHeight());
     }
 
+    /**
+     * @covers ::setHeight
+     */
     public function testSetHeight()
     {
         $obj = new SVGImage();
@@ -140,6 +176,9 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setHeight(42));
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $obj = new SVGImage('test-href', 10, 10, 100, 100);

--- a/tests/Nodes/SVGNodeContainerTest.php
+++ b/tests/Nodes/SVGNodeContainerTest.php
@@ -10,10 +10,17 @@ class SVGNodeContainerSubclass extends SVGNodeContainer
 }
 
 /**
+ * @coversDefaultClass \SVG\Nodes\SVGNodeContainer
+ * @covers ::<!public>
+ * @covers ::__construct
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::addChild
+     */
     public function testAddChild()
     {
         $obj = new SVGNodeContainerSubclass();
@@ -57,6 +64,9 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($child3, $obj->getChild(2));
     }
 
+    /**
+     * @covers ::removeChild
+     */
     public function testRemoveChild()
     {
         $obj = new SVGNodeContainerSubclass();
@@ -84,6 +94,9 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->removeChild($child));
     }
 
+    /**
+     * @covers ::setChild
+     */
     public function testSetChild()
     {
         $obj = new SVGNodeContainerSubclass();
@@ -113,6 +126,9 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setChild(0, $child2));
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $obj = new SVGNodeContainerSubclass();
@@ -133,6 +149,9 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         $obj->rasterize($rast);
     }
 
+    /**
+     * @covers ::getElementsByTagName
+     */
     public function testGetElementsByTagName()
     {
         $obj = new SVGNodeContainerSubclass();
@@ -176,6 +195,9 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         ), $obj->getElementsByTagName('*'));
     }
 
+    /**
+     * @covers ::getElementsByClassName
+     */
     public function testGetElementsByClassName()
     {
         $obj = new SVGNodeContainerSubclass();
@@ -231,8 +253,14 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(
             $root_1_0_0, $root_1_1,
         ), $obj->getElementsByClassName(array('foo', 'bar')));
+
+        // should return 0 elements with empty class name
+        $this->assertCount(0, $obj->getElementsByClassName(''));
     }
 
+    /**
+     * @covers ::getContainerStyleForNode
+     */
     public function testGetContainerStyleForNode()
     {
         $obj = new SVGNodeContainerSubclass();
@@ -243,6 +271,9 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(0, $obj->getContainerStyleForNode($mockChild));
     }
 
+    /**
+     * @covers ::getContainerStyleByPattern
+     */
     public function testGetContainerStyleByPattern()
     {
         $obj = new SVGNodeContainerSubclass();
@@ -251,12 +282,5 @@ class SVGNodeContainerTest extends \PHPUnit\Framework\TestCase
         $obj->addChild($mockChild);
 
         $this->assertCount(0, $obj->getContainerStyleByPattern('/^(\d+)?\.\d+$/'));
-    }
-
-    public function testGetElementsByClassNameWithEmptyClassName()
-    {
-        $obj = (new SVGNodeContainerSubclass());
-
-        $this->assertCount(0, $obj->getElementsByClassName(''));
     }
 }

--- a/tests/Nodes/SVGNodeTest.php
+++ b/tests/Nodes/SVGNodeTest.php
@@ -17,10 +17,17 @@ class SVGNodeSubclass extends SVGNode
 }
 
 /**
+ * @coversDefaultClass \SVG\Nodes\SVGNode
+ * @covers ::<!public>
+ * @covers ::__construct
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGNodeTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::getName
+     */
     public function testGetName()
     {
         $obj = new SVGNodeSubclass();
@@ -29,6 +36,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(SVGNodeSubclass::TAG_NAME, $obj->getName());
     }
 
+    /**
+     * @covers ::getParent
+     */
     public function testGetParent()
     {
         $obj = new SVGNodeSubclass();
@@ -37,6 +47,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($obj->getParent());
     }
 
+    /**
+     * @covers ::getValue
+     */
     public function testGetValue()
     {
         $obj = new SVGNodeSubclass();
@@ -45,6 +58,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('', $obj->getValue());
     }
 
+    /**
+     * @covers ::setValue
+     */
     public function testSetValue()
     {
         $obj = new SVGNodeSubclass();
@@ -61,6 +77,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setValue('foo'));
     }
 
+    /**
+     * @covers ::getStyle
+     */
     public function testGetStyle()
     {
         $obj = new SVGNodeSubclass();
@@ -69,6 +88,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($obj->getStyle('fill'));
     }
 
+    /**
+     * @covers ::setStyle
+     */
     public function testSetStyle()
     {
         $obj = new SVGNodeSubclass();
@@ -98,6 +120,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setStyle('fill', null));
     }
 
+    /**
+     * @covers ::removeStyle
+     */
     public function testRemoveStyle()
     {
         $obj = new SVGNodeSubclass();
@@ -111,6 +136,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->removeStyle('fill'));
     }
 
+    /**
+     * @covers ::getAttribute
+     */
     public function testGetAttribute()
     {
         $obj = new SVGNodeSubclass();
@@ -119,6 +147,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($obj->getAttribute('x'));
     }
 
+    /**
+     * @covers ::setAttribute
+     */
     public function testSetAttribute()
     {
         $obj = new SVGNodeSubclass();
@@ -148,6 +179,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setAttribute('x', null));
     }
 
+    /**
+     * @covers ::removeAttribute
+     */
     public function testRemoveAttribute()
     {
         $obj = new SVGNodeSubclass();
@@ -161,6 +195,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->removeAttribute('x'));
     }
 
+    /**
+     * @covers ::getSerializableNamespaces
+     */
     public function testGetSerializableNamespaces()
     {
         $obj = new SVGNodeSubclass();
@@ -173,6 +210,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($ns, $obj->getSerializableNamespaces());
     }
 
+    /**
+     * @covers ::getSerializableAttributes
+     */
     public function testGetSerializableAttributes()
     {
         $obj = new SVGNodeSubclass();
@@ -188,6 +228,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::getSerializableStyles
+     */
     public function testGetSerializableStyles()
     {
         $obj = new SVGNodeSubclass();
@@ -201,6 +244,9 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableStyles());
     }
 
+    /**
+     * @covers ::getViewBox
+     */
     public function testGetViewBox()
     {
         $obj = new SVGNodeSubclass();

--- a/tests/Nodes/Shapes/SVGCircleTest.php
+++ b/tests/Nodes/Shapes/SVGCircleTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Nodes\Shapes\SVGCircle;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Shapes\SVGCircle
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGCircleTest extends \PHPUnit\Framework\TestCase
 {
+  /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should not set any attributes by default
@@ -24,6 +30,9 @@ class SVGCircleTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::getCenterX
+     */
     public function testGetCenterX()
     {
         $obj = new SVGCircle();
@@ -33,6 +42,9 @@ class SVGCircleTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getCenterX());
     }
 
+    /**
+     * @covers ::setCenterX
+     */
     public function testSetCenterX()
     {
         $obj = new SVGCircle();
@@ -45,6 +57,9 @@ class SVGCircleTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setCenterX(42));
     }
 
+    /**
+     * @covers ::getCenterY
+     */
     public function testGetCenterY()
     {
         $obj = new SVGCircle();
@@ -54,6 +69,9 @@ class SVGCircleTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getCenterY());
     }
 
+    /**
+     * @covers ::setCenterY
+     */
     public function testSetCenterY()
     {
         $obj = new SVGCircle();
@@ -66,6 +84,9 @@ class SVGCircleTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setCenterY(42));
     }
 
+    /**
+     * @covers ::getRadius
+     */
     public function testGetRadius()
     {
         $obj = new SVGCircle();
@@ -75,6 +96,9 @@ class SVGCircleTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getRadius());
     }
 
+    /**
+     * @covers ::setRadius
+     */
     public function testSetRadius()
     {
         $obj = new SVGCircle();
@@ -87,6 +111,9 @@ class SVGCircleTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setRadius(42));
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $obj = new SVGCircle(37, 42, 100);

--- a/tests/Nodes/Shapes/SVGEllipseTest.php
+++ b/tests/Nodes/Shapes/SVGEllipseTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Nodes\Shapes\SVGEllipse;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Shapes\SVGEllipse
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGEllipseTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should not set any attributes by default
@@ -25,6 +31,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::getCenterX
+     */
     public function testGetCenterX()
     {
         $obj = new SVGEllipse();
@@ -34,6 +43,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getCenterX());
     }
 
+    /**
+     * @covers ::setCenterX
+     */
     public function testSetCenterX()
     {
         $obj = new SVGEllipse();
@@ -46,6 +58,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setCenterX(42));
     }
 
+    /**
+     * @covers ::getCenterY
+     */
     public function testGetCenterY()
     {
         $obj = new SVGEllipse();
@@ -55,6 +70,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getCenterY());
     }
 
+    /**
+     * @covers ::setCenterY
+     */
     public function testSetCenterY()
     {
         $obj = new SVGEllipse();
@@ -67,6 +85,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setCenterY(42));
     }
 
+    /**
+     * @covers ::getRadiusX
+     */
     public function testGetRadiusX()
     {
         $obj = new SVGEllipse();
@@ -76,6 +97,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getRadiusX());
     }
 
+    /**
+     * @covers ::setRadiusX
+     */
     public function testSetRadiusX()
     {
         $obj = new SVGEllipse();
@@ -88,6 +112,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setRadiusX(42));
     }
 
+    /**
+     * @covers ::getRadiusY
+     */
     public function testGetRadiusY()
     {
         $obj = new SVGEllipse();
@@ -97,6 +124,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getRadiusY());
     }
 
+    /**
+     * @covers ::setRadiusY
+     */
     public function testSetRadiusY()
     {
         $obj = new SVGEllipse();
@@ -109,6 +139,9 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setRadiusY(42));
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $obj = new SVGEllipse(37, 42, 100, 200);

--- a/tests/Nodes/Shapes/SVGLineTest.php
+++ b/tests/Nodes/Shapes/SVGLineTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Nodes\Shapes\SVGLine;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Shapes\SVGLine
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGLineTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should not set any attributes by default
@@ -25,6 +31,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::getX1
+     */
     public function testGetX1()
     {
         $obj = new SVGLine();
@@ -34,6 +43,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getX1());
     }
 
+    /**
+     * @covers ::setX1
+     */
     public function testSetX1()
     {
         $obj = new SVGLine();
@@ -46,6 +58,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setX1(42));
     }
 
+    /**
+     * @covers ::getY1
+     */
     public function testGetY1()
     {
         $obj = new SVGLine();
@@ -55,6 +70,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getY1());
     }
 
+    /**
+     * @covers ::setY1
+     */
     public function testSetY1()
     {
         $obj = new SVGLine();
@@ -67,6 +85,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setY1(42));
     }
 
+    /**
+     * @covers ::getX2
+     */
     public function testGetX2()
     {
         $obj = new SVGLine();
@@ -76,6 +97,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getX2());
     }
 
+    /**
+     * @covers ::setX2
+     */
     public function testSetX2()
     {
         $obj = new SVGLine();
@@ -88,6 +112,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setX2(42));
     }
 
+    /**
+     * @covers ::getY2
+     */
     public function testGetY2()
     {
         $obj = new SVGLine();
@@ -97,6 +124,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getY2());
     }
 
+    /**
+     * @covers ::setY2
+     */
     public function testSetY2()
     {
         $obj = new SVGLine();
@@ -109,6 +139,9 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setY2(42));
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $obj = new SVGLine(11, 12, 13, 14);

--- a/tests/Nodes/Shapes/SVGPathTest.php
+++ b/tests/Nodes/Shapes/SVGPathTest.php
@@ -5,6 +5,9 @@ namespace SVG;
 use SVG\Nodes\Shapes\SVGPath;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Shapes\SVGPath
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGPathTest extends \PHPUnit\Framework\TestCase
@@ -22,6 +25,9 @@ class SVGPathTest extends \PHPUnit\Framework\TestCase
         array(array(200, 200), array(220, 200)),
     );
 
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should not set any attributes by default
@@ -35,6 +41,9 @@ class SVGPathTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::getDescription
+     */
     public function testGetDescription()
     {
         $obj = new SVGPath();
@@ -44,6 +53,9 @@ class SVGPathTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(self::$sampleDescription, $obj->getDescription());
     }
 
+    /**
+     * @covers ::setDescription
+     */
     public function testSetDescription()
     {
         $obj = new SVGPath();
@@ -56,16 +68,25 @@ class SVGPathTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setDescription(self::$sampleDescription));
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterizeWithNull()
     {
+        $obj = new SVGPath();
+
         $rast = $this->getMockBuilder('\SVG\Rasterization\SVGRasterizer')
             ->disableOriginalConstructor()
             ->getMock();
-        $obj = new SVGPath();
 
-        $this->assertNull($obj->rasterize($rast));
+        // should not manipulate anything
+        $rast->expects($this->never())->method($this->anything());
+        $obj->rasterize($rast);
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $obj = new SVGPath(self::$sampleDescription);

--- a/tests/Nodes/Shapes/SVGPolygonTest.php
+++ b/tests/Nodes/Shapes/SVGPolygonTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Nodes\Shapes\SVGPolygon;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Shapes\SVGPolygon
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGPolygonTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should set empty points by default
@@ -24,6 +30,9 @@ class SVGPolygonTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($points, $obj->getPoints());
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $points = array(

--- a/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
+++ b/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
@@ -23,7 +23,7 @@ class SVGPolygonalShapeSubclass extends SVGPolygonalShape
 
 /**
  * @coversDefaultClass \SVG\Nodes\Shapes\SVGPolygonalShape
- * @covers ::<private>
+ * @covers ::<!public>
  *
  * @SuppressWarnings(PHPMD)
  */

--- a/tests/Nodes/Shapes/SVGPolylineTest.php
+++ b/tests/Nodes/Shapes/SVGPolylineTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Nodes\Shapes\SVGPolyline;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Shapes\SVGPolyline
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGPolylineTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should set empty points by default
@@ -24,6 +30,9 @@ class SVGPolylineTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($points, $obj->getPoints());
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $points = array(

--- a/tests/Nodes/Shapes/SVGRectTest.php
+++ b/tests/Nodes/Shapes/SVGRectTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Nodes\Shapes\SVGRect;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Shapes\SVGRect
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGRectTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should not set any attributes by default
@@ -25,6 +31,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::getX
+     */
     public function testGetX()
     {
         $obj = new SVGRect();
@@ -34,6 +43,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getX());
     }
 
+    /**
+     * @covers ::setX
+     */
     public function testSetX()
     {
         $obj = new SVGRect();
@@ -46,6 +58,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setX(42));
     }
 
+    /**
+     * @covers ::getY
+     */
     public function testGetY()
     {
         $obj = new SVGRect();
@@ -55,6 +70,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getY());
     }
 
+    /**
+     * @covers ::setY
+     */
     public function testSetY()
     {
         $obj = new SVGRect();
@@ -67,6 +85,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setY(42));
     }
 
+    /**
+     * @covers ::getWidth
+     */
     public function testGetWidth()
     {
         $obj = new SVGRect();
@@ -76,6 +97,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getWidth());
     }
 
+    /**
+     * @covers ::setWidth
+     */
     public function testSetWidth()
     {
         $obj = new SVGRect();
@@ -88,6 +112,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setWidth(42));
     }
 
+    /**
+     * @covers ::getHeight
+     */
     public function testGetHeight()
     {
         $obj = new SVGRect();
@@ -97,6 +124,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getHeight());
     }
 
+    /**
+     * @covers ::setHeight
+     */
     public function testSetHeight()
     {
         $obj = new SVGRect();
@@ -109,6 +139,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setHeight(42));
     }
 
+    /**
+     * @covers ::getRX
+     */
     public function testGetRX()
     {
         $obj = new SVGRect();
@@ -118,6 +151,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getRX());
     }
 
+    /**
+     * @covers ::setRX
+     */
     public function testSetRX()
     {
         $obj = new SVGRect();
@@ -130,6 +166,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setRX(42));
     }
 
+    /**
+     * @covers ::getRY
+     */
     public function testGetRY()
     {
         $obj = new SVGRect();
@@ -139,6 +178,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getRY());
     }
 
+    /**
+     * @covers ::setRY
+     */
     public function testSetRY()
     {
         $obj = new SVGRect();
@@ -151,6 +193,9 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setRY(42));
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $obj = new SVGRect(37, 42, 100, 200);

--- a/tests/Nodes/Structures/SVGDefsTest.php
+++ b/tests/Nodes/Structures/SVGDefsTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Nodes\Structures\SVGDefs;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Structures\SVGDefs
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGDefsTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should not set any attributes by default
@@ -16,6 +22,9 @@ class SVGDefsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::rasterize
+     */
     public function testRasterize()
     {
         $obj = new SVGDefs();

--- a/tests/Nodes/Structures/SVGDocumentFragmentTest.php
+++ b/tests/Nodes/Structures/SVGDocumentFragmentTest.php
@@ -6,10 +6,16 @@ use AssertGD\GDSimilarityConstraint;
 use SVG\Nodes\Structures\SVGDocumentFragment;
 
 /**
+ * @coversDefaultClass \SVG\Nodes\Structures\SVGDocumentFragment
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         $container = new \SVG\Nodes\Structures\SVGGroup();
@@ -25,6 +31,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getHeight());
     }
 
+    /**
+     * @covers ::isRoot
+     */
     public function testIsRoot()
     {
         // should return true by default
@@ -37,6 +46,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($obj->isRoot());
     }
 
+    /**
+     * @covers ::getWidth
+     */
     public function testGetWidth()
     {
         $obj = new SVGDocumentFragment();
@@ -46,6 +58,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getWidth());
     }
 
+    /**
+     * @covers ::setWidth
+     */
     public function testSetWidth()
     {
         $obj = new SVGDocumentFragment();
@@ -58,6 +73,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setWidth(42));
     }
 
+    /**
+     * @covers ::getHeight
+     */
     public function testGetHeight()
     {
         $obj = new SVGDocumentFragment();
@@ -67,6 +85,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $obj->getHeight());
     }
 
+    /**
+     * @covers ::setHeight
+     */
     public function testSetHeight()
     {
         $obj = new SVGDocumentFragment();
@@ -79,6 +100,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($obj, $obj->setHeight(42));
     }
 
+    /**
+     * @covers ::getComputedStyle
+     */
     public function testGetComputedStyle()
     {
         $obj = new SVGDocumentFragment();
@@ -97,6 +121,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('#FFFFFF', $obj->getComputedStyle('fill'));
     }
 
+    /**
+     * @covers ::getSerializableNamespaces
+     */
     public function testGetSerializableNamespaces()
     {
         // should include 'xmlns' and 'xmlns:xlink' namespaces for root
@@ -130,6 +157,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         ), $obj->getSerializableNamespaces());
     }
 
+    /**
+     * @covers ::getSerializableAttributes
+     */
     public function testGetSerializableAttributes()
     {
         $container = new \SVG\Nodes\Structures\SVGGroup();
@@ -162,6 +192,9 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(), $obj->getSerializableAttributes());
     }
 
+    /**
+     * @covers ::getElementById
+     */
     public function testGetElementById()
     {
         // should return null if not found
@@ -203,8 +236,11 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expected, $obj->getElementById('foobar'));
     }
 
+    // ---- THE FOLLOWING TESTS ARE INTEGRATION TESTS ----
+
     /**
      * @requires extension gd
+     * @coversNothing
      */
     public function testRasterize_empty()
     {
@@ -225,6 +261,7 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @requires extension gd
+     * @coversNothing
      */
     public function testRasterize_object_unscaled()
     {
@@ -249,6 +286,7 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @requires extension gd
+     * @coversNothing
      */
     public function testRasterize_object_scaledUp()
     {
@@ -273,6 +311,7 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @requires extension gd
+     * @coversNothing
      */
     public function testRasterize_object_scaledDown()
     {
@@ -297,6 +336,7 @@ class SVGDocumentFragmentTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @requires extension gd
+     * @coversNothing
      */
     public function testRasterize_object_viewBox()
     {

--- a/tests/Rasterization/Path/ArcApproximatorTest.php
+++ b/tests/Rasterization/Path/ArcApproximatorTest.php
@@ -5,14 +5,12 @@ namespace SVG;
 use SVG\Rasterization\Path\ArcApproximator;
 
 /**
+ * @covers SVG\Rasterization\Path\ArcApproximator
+ *
  * @SuppressWarnings(PHPMD)
  */
 class ArcApproximatorTest extends \PHPUnit\Framework\TestCase
 {
-    // THE TESTS IN THIS CLASS DO NOT ADHERE TO THE STANDARD LAYOUT
-    // OF TESTING ONE CLASS METHOD PER TEST METHOD
-    // BECAUSE THE CLASS UNDER TEST IS A SINGLE-FEATURE CLASS
-
     public function testApproximate()
     {
         $approx = new ArcApproximator();

--- a/tests/Rasterization/Path/BezierApproximatorTest.php
+++ b/tests/Rasterization/Path/BezierApproximatorTest.php
@@ -5,6 +5,8 @@ namespace SVG;
 use SVG\Rasterization\Path\BezierApproximator;
 
 /**
+ * @covers \SVG\Rasterization\Path\BezierApproximator
+ *
  * @SuppressWarnings(PHPMD)
  */
 class BezierApproximatorTest extends \PHPUnit\Framework\TestCase

--- a/tests/Rasterization/Path/PathApproximatorTest.php
+++ b/tests/Rasterization/Path/PathApproximatorTest.php
@@ -5,6 +5,8 @@ namespace SVG;
 use SVG\Rasterization\Path\PathApproximator;
 
 /**
+ * @covers \SVG\Rasterization\Path\PathApproximator
+ *
  * @SuppressWarnings(PHPMD)
  */
 class PathApproximatorTest extends \PHPUnit\Framework\TestCase

--- a/tests/Rasterization/Path/PathParserTest.php
+++ b/tests/Rasterization/Path/PathParserTest.php
@@ -5,14 +5,12 @@ namespace SVG;
 use SVG\Rasterization\Path\PathParser;
 
 /**
+ * @covers \SVG\Rasterization\Path\PathParser
+ *
  * @SuppressWarnings(PHPMD)
  */
 class PathParserTest extends \PHPUnit\Framework\TestCase
 {
-    // THE TESTS IN THIS CLASS DO NOT ADHERE TO THE STANDARD LAYOUT
-    // OF TESTING ONE CLASS METHOD PER TEST METHOD
-    // BECAUSE THE CLASS UNDER TEST IS A SINGLE-FEATURE CLASS
-
     public function testShouldSplitCorrectly()
     {
         $obj = new PathParser();

--- a/tests/Rasterization/Path/PolygonBuilderTest.php
+++ b/tests/Rasterization/Path/PolygonBuilderTest.php
@@ -5,10 +5,16 @@ namespace SVG;
 use SVG\Rasterization\Path\PolygonBuilder;
 
 /**
+ * @coversDefaultClass \SVG\Rasterization\Path\PolygonBuilder
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class PolygonBuilderTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::__construct
+     */
     public function test__construct()
     {
         // should set position to origin by default
@@ -20,6 +26,9 @@ class PolygonBuilderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(37.1, 42.2), $obj->getPosition());
     }
 
+    /**
+     * @covers ::build
+     */
     public function testBuild()
     {
         // should return an array of float 2-tuples
@@ -32,6 +41,9 @@ class PolygonBuilderTest extends \PHPUnit\Framework\TestCase
         ), $obj->build());
     }
 
+    /**
+     * @covers ::getFirstPoint
+     */
     public function testGetFirstPoint()
     {
         $obj = new PolygonBuilder();
@@ -45,6 +57,9 @@ class PolygonBuilderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(10, 20), $obj->getFirstPoint());
     }
 
+    /**
+     * @covers ::getLastPoint
+     */
     public function testGetLastPoint()
     {
         $obj = new PolygonBuilder();
@@ -58,6 +73,9 @@ class PolygonBuilderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(37.1, 42.2), $obj->getLastPoint());
     }
 
+    /**
+     * @covers ::getPosition
+     */
     public function testGetPosition()
     {
         $obj = new PolygonBuilder(10, 20);
@@ -70,6 +88,9 @@ class PolygonBuilderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(37.1, 42.2), $obj->getPosition());
     }
 
+    /**
+     * @covers ::addPoint
+     */
     public function testAddPoint()
     {
         $obj = new PolygonBuilder();
@@ -96,6 +117,9 @@ class PolygonBuilderTest extends \PHPUnit\Framework\TestCase
         ), $obj->build());
     }
 
+    /**
+     * @covers ::addPointRelative
+     */
     public function testAddPointRelative()
     {
         $obj = new PolygonBuilder();
@@ -120,6 +144,9 @@ class PolygonBuilderTest extends \PHPUnit\Framework\TestCase
         ), $obj->build());
     }
 
+    /**
+     * @covers ::addPoints
+     */
     public function testAddPoints()
     {
         $obj = new PolygonBuilder();

--- a/tests/Rasterization/Renderers/ImageRendererTest.php
+++ b/tests/Rasterization/Renderers/ImageRendererTest.php
@@ -18,9 +18,10 @@ class SVGNodeClass extends SVGNode
 }
 
 /**
- * @SuppressWarnings(PHPMD)
- *
  * @requires extension gd
+ * @covers \SVG\Rasterization\Renderers\ImageRenderer
+ *
+ * @SuppressWarnings(PHPMD)
  */
 class ImageRendererTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Rasterization/Renderers/MultiPassRendererTest.php
+++ b/tests/Rasterization/Renderers/MultiPassRendererTest.php
@@ -2,12 +2,13 @@
 
 namespace SVG;
 
-use SVG\Rasterization\Renderers\Renderer;
+use SVG\Rasterization\Renderers\MultiPassRenderer;
 
 /**
- * @SuppressWarnings(PHPMD)
- *
  * @requires extension gd
+ * @covers \SVG\Rasterization\Renderers\MultiPassRenderer
+ *
+ * @SuppressWarnings(PHPMD)
  */
 class MultiPassRendererTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Rasterization/Renderers/RectRendererTest.php
+++ b/tests/Rasterization/Renderers/RectRendererTest.php
@@ -7,9 +7,10 @@ use SVG\Rasterization\SVGRasterizer;
 use SVG\Rasterization\Renderers\RectRenderer;
 
 /**
- * @SuppressWarnings(PHPMD)
- *
  * @requires extension gd
+ * @covers \SVG\Rasterization\Renderers\RectRenderer
+ *
+ * @SuppressWarnings(PHPMD)
  */
 class RectRendererTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Rasterization/SVGRasterizerTest.php
+++ b/tests/Rasterization/SVGRasterizerTest.php
@@ -6,12 +6,17 @@ use AssertGD\GDSimilarityConstraint;
 use SVG\Rasterization\SVGRasterizer;
 
 /**
- * @SuppressWarnings(PHPMD)
- *
  * @requires extension gd
+ * @coversDefaultClass \SVG\Rasterization\SVGRasterizer
+ * @covers ::<!public>
+ *
+ * @SuppressWarnings(PHPMD)
  */
 class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @covers ::getPathParser
+     */
     public function testGetPathParser()
     {
         // should return an instance of PathParser
@@ -20,6 +25,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getPathApproximator
+     */
     public function testGetPathApproximator()
     {
         // should return an instance of PathApproximator
@@ -28,6 +36,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getDocumentWidth
+     */
     public function testGetDocumentWidth()
     {
         // should return parsed unit relative to target size
@@ -41,6 +52,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getDocumentHeight
+     */
     public function testGetDocumentHeight()
     {
         // should return parsed unit relative to target size
@@ -54,6 +68,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getWidth
+     */
     public function testGetWidth()
     {
         // should return the constructor parameter
@@ -62,6 +79,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getHeight
+     */
     public function testGetHeight()
     {
         // should return the constructor parameter
@@ -70,6 +90,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getScaleX
+     */
     public function testGetScaleX()
     {
         // should use viewBox dimension when available
@@ -83,6 +106,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getScaleY
+     */
     public function testGetScaleY()
     {
         // should use viewBox dimension when available
@@ -96,6 +122,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getOffsetX
+     */
     public function testGetOffsetX()
     {
         // should return scaled viewBox offset when available
@@ -109,6 +138,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getOffsetY
+     */
     public function testGetOffsetY()
     {
         // should return scaled viewBox offset when available
@@ -122,6 +154,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getViewbox
+     */
     public function testGetViewbox()
     {
         // should return the constructor parameter
@@ -135,6 +170,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::getImage
+     */
     public function testGetImage()
     {
         $obj = new SVGRasterizer(10, 20, array(), 100, 200);
@@ -150,6 +188,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
+    /**
+     * @covers ::render
+     */
     public function testRenderWithNoSuchRenderId()
     {
         $this->setExpectedException('\InvalidArgumentException');
@@ -159,6 +200,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         $obj->render('invalid_render_id', array('option' => 'value'), $mockChild);
     }
 
+    /**
+     * @covers \SVG\Rasterization\SVGRasterizer
+     */
     public function testShouldRenderBackgroundTransparent()
     {
         $obj = new SVGRasterizer(32, 32, array(), 32, 32, null);
@@ -169,6 +213,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($img);
     }
 
+    /**
+     * @covers \SVG\Rasterization\SVGRasterizer
+     */
     public function testShouldRenderBackgroundSolidWhite()
     {
         $obj = new SVGRasterizer(32, 32, array(), 32, 32, "#FFFFFF");
@@ -179,6 +226,9 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($img);
     }
 
+    /**
+     * @covers \SVG\Rasterization\SVGRasterizer
+     */
     public function testShouldRenderBackgroundWhiteSemitransparent()
     {
         $obj = new SVGRasterizer(32, 32, array(), 32, 32, "rgba(255,255,255,.5)");

--- a/tests/Reading/AttributeRegistryTest.php
+++ b/tests/Reading/AttributeRegistryTest.php
@@ -7,6 +7,7 @@ use SVG\Reading\AttributeRegistry;
 
 /**
  * @coversDefaultClass \SVG\Reading\AttributeRegistry
+ * @covers ::<!public>
  *
  * @SuppressWarnings(PHPMD)
  */

--- a/tests/Reading/LengthAttributeConverterTest.php
+++ b/tests/Reading/LengthAttributeConverterTest.php
@@ -5,13 +5,12 @@ namespace SVG;
 use SVG\Reading\LengthAttributeConverter;
 
 /**
+ * @covers \SVG\Reading\LengthAttributeConverter
+ *
  * @SuppressWarnings(PHPMD)
  */
 class LengthAttributeConverterTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @covers \SVG\Reading\LengthAttributeConverter
-     */
     public function testShouldQualifyUnitlessNumbers()
     {
         $obj = LengthAttributeConverter::getInstance();
@@ -25,9 +24,6 @@ class LengthAttributeConverterTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('-42.123px', $obj->convert('-42.123'));
     }
 
-    /**
-     * @covers \SVG\Reading\LengthAttributeConverter
-     */
     public function testShouldTrimWhitespace()
     {
         $obj = LengthAttributeConverter::getInstance();
@@ -37,9 +33,6 @@ class LengthAttributeConverterTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('-42.123px', $obj->convert(" \n -42.123 \n "));
     }
 
-    /**
-     * @covers \SVG\Reading\LengthAttributeConverter
-     */
     public function testShouldIgnoreOtherValues()
     {
         $obj = LengthAttributeConverter::getInstance();

--- a/tests/Reading/NodeRegistryTest.php
+++ b/tests/Reading/NodeRegistryTest.php
@@ -6,13 +6,12 @@ use SimpleXMLElement;
 use SVG\Reading\NodeRegistry;
 
 /**
+ * @covers \SVG\Reading\NodeRegistry
+ *
  * @SuppressWarnings(PHPMD)
  */
 class NodeRegistryTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @covers \SVG\Reading\NodeRegistry
-     */
     public function testShouldConstructKnownTypes()
     {
         $xml = new SimpleXMLElement('<rect />');
@@ -21,9 +20,6 @@ class NodeRegistryTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('SVG\Nodes\Shapes\SVGRect', $result);
     }
 
-    /**
-     * @covers \SVG\Reading\NodeRegistry
-     */
     public function testShouldUseGenericTypeForOthers()
     {
         $xml = new SimpleXMLElement('<div />');

--- a/tests/Reading/SVGReaderTest.php
+++ b/tests/Reading/SVGReaderTest.php
@@ -5,6 +5,8 @@ namespace SVG;
 use SVG\Reading\SVGReader;
 
 /**
+ * @covers SVG\Reading\SVGReader
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGReaderTest extends \PHPUnit\Framework\TestCase
@@ -70,9 +72,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->xmlEntities .= '</svg>';
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldReturnAnImageOrNull()
     {
         // should return an instance of SVG
@@ -85,9 +84,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($result);
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldSetAllAttributesAndNamespaces()
     {
         // should retain all document attributes and namespaces
@@ -130,9 +126,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         ), $rect->getSerializableAttributes());
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldSetStyles()
     {
         $svgReader = new SVGReader();
@@ -148,9 +141,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('#AABBCC', $rect->getStyle('stroke'));
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldConvertUnitlessCSSLengths()
     {
         $code  = '<svg xmlns="http://www.w3.org/2000/svg">';
@@ -167,9 +157,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('3px', $text->getStyle('word-spacing'));
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldRecursivelyAddChildren()
     {
         // should recursively add all child nodes
@@ -195,9 +182,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         ), $ellipse->getSerializableAttributes());
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldWorkWithoutAnyXmlns()
     {
         $svgReader = new SVGReader();
@@ -209,9 +193,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('10', $doc->getChild(0)->getAttribute('cx'));
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldWorkWithoutMainXmlns()
     {
         $svgReader = new SVGReader();
@@ -224,9 +205,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('bar', $doc->getChild(0)->getAttribute('xlink:foo'));
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldRetrieveUnknownNodes()
     {
         $svgReader = new SVGReader();
@@ -247,9 +225,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('baz', $doc->getChild(1)->getChild(0)->getName());
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldSetValue()
     {
         $svgReader = new SVGReader();
@@ -260,9 +235,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('hello world', $doc->getChild(0)->getValue());
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldDecodeEntities()
     {
         $svgReader = new SVGReader();
@@ -280,9 +252,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('" foo&bar>', $doc->getChild(1)->getValue());
     }
 
-    /**
-     * @covers SVG\Reading\SVGReader
-     */
     public function testShouldRemoveCDataForStyles()
     {
         // should remove CDATA
@@ -299,7 +268,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
     // not accepting 2 arguments below 5.4
     /**
      * @requires PHP 5.4
-     * @covers SVG\Reading\SVGReader
      */
     public function testChildKeepsNamespaces()
     {
@@ -319,7 +287,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @requires PHP 5.4
-     * @covers SVG\Reading\SVGReader
      */
     public function testParsesChildNamespacedAttributes()
     {

--- a/tests/SVGTest.php
+++ b/tests/SVGTest.php
@@ -5,6 +5,9 @@ namespace SVG;
 use SVG\SVG;
 
 /**
+ * @coversDefaultClass \SVG\SVG
+ * @covers ::<!public>
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGTest extends \PHPUnit\Framework\TestCase
@@ -26,19 +29,9 @@ class SVGTest extends \PHPUnit\Framework\TestCase
             'width="37" height="42" />';
     }
 
-    public function testGetDocument()
-    {
-        $image = new SVG();
-        $doc = $image->getDocument();
-
-        // should be instanceof the correct class
-        $docFragClass = '\SVG\Nodes\Structures\SVGDocumentFragment';
-        $this->assertInstanceOf($docFragClass, $doc);
-
-        // should be set to root
-        $this->assertTrue($doc->isRoot());
-    }
-
+    /**
+     * @covers ::__construct
+     */
     public function testConstructSetsDocumentDimensions()
     {
         $image = new SVG();
@@ -53,7 +46,24 @@ class SVGTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::getDocument
+     */
+    public function testGetDocument()
+    {
+        $image = new SVG();
+        $doc = $image->getDocument();
+
+        // should be instanceof the correct class
+        $docFragClass = '\SVG\Nodes\Structures\SVGDocumentFragment';
+        $this->assertInstanceOf($docFragClass, $doc);
+
+        // should be set to root
+        $this->assertTrue($doc->isRoot());
+    }
+
+    /**
      * @requires extension gd
+     * @covers ::toRasterImage
      */
     public function testToRasterImage()
     {
@@ -69,6 +79,9 @@ class SVGTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(200, imagesy($rasterImage));
     }
 
+    /**
+     * @covers ::__toString
+     */
     public function test__toString()
     {
         $image = new SVG(37, 42);
@@ -77,6 +90,9 @@ class SVGTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($this->xml, (string) $image);
     }
 
+    /**
+     * @covers ::toXMLString
+     */
     public function testToXMLString()
     {
         $image = new SVG(37, 42);
@@ -88,6 +104,9 @@ class SVGTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($this->xmlNoDeclaration, $image->toXMLString(false));
     }
 
+    /**
+     * @covers ::fromString
+     */
     public function testFromString()
     {
         $image = SVG::fromString($this->xml);
@@ -108,6 +127,9 @@ class SVGTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('42', $doc->getHeight());
     }
 
+    /**
+     * @covers ::fromFile
+     */
     public function testFromFile()
     {
         $image = SVG::fromFile(__DIR__ . '/php_test.svg');

--- a/tests/Utilities/Colors/ColorLookupTest.php
+++ b/tests/Utilities/Colors/ColorLookupTest.php
@@ -5,6 +5,8 @@ namespace SVG;
 use SVG\Utilities\Colors\ColorLookup;
 
 /**
+ * @covers \SVG\Utilities\Colors\ColorLookup
+ *
  * @SuppressWarnings(PHPMD)
  */
 class ColorLookupTest extends \PHPUnit\Framework\TestCase

--- a/tests/Utilities/Colors/ColorTest.php
+++ b/tests/Utilities/Colors/ColorTest.php
@@ -5,6 +5,8 @@ namespace SVG;
 use SVG\Utilities\Colors\Color;
 
 /**
+ * @covers \SVG\Utilities\Colors\Color
+ *
  * @SuppressWarnings(PHPMD)
  */
 class ColorTest extends \PHPUnit\Framework\TestCase

--- a/tests/Utilities/SVGStyleParserTest.php
+++ b/tests/Utilities/SVGStyleParserTest.php
@@ -5,21 +5,17 @@ namespace SVG;
 use SVG\Utilities\SVGStyleParser;
 
 /**
+ * @covers SVG\Utilities\SVGStyleParser
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGStyleParserTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @covers SVG\Utilities\SVGStyleParser
-     */
     public function testParseStylesWithEmptyString()
     {
         $this->assertCount(0, SVGStyleParser::parseStyles(''));
     }
 
-    /**
-     * @covers SVG\Utilities\SVGStyleParser
-     */
     public function testParseCssWithMatchedElement()
     {
         $result = SVGStyleParser::parseCss('svg {background-color: beige;}');
@@ -27,9 +23,6 @@ class SVGStyleParserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('beige', $result['svg']['background-color']);
     }
 
-    /**
-     * @covers SVG\Utilities\SVGStyleParser
-     */
     public function testParseCssWithSkippedElement()
     {
         $result = SVGStyleParser::parseCss('@font-face {font-family: "Bitstream Vera Serif Bold";}');

--- a/tests/Utilities/Units/AngleTest.php
+++ b/tests/Utilities/Units/AngleTest.php
@@ -5,6 +5,8 @@ namespace SVG;
 use SVG\Utilities\Units\Angle;
 
 /**
+ * @covers \SVG\Utilities\Units\Angle
+ *
  * @SuppressWarnings(PHPMD)
  */
 class AngleTest extends \PHPUnit\Framework\TestCase

--- a/tests/Utilities/Units/LengthTest.php
+++ b/tests/Utilities/Units/LengthTest.php
@@ -5,6 +5,8 @@ namespace SVG;
 use SVG\Utilities\Units\Length;
 
 /**
+ * @covers \SVG\Utilities\Units\Length
+ *
  * @SuppressWarnings(PHPMD)
  */
 class LengthTest extends \PHPUnit\Framework\TestCase

--- a/tests/Writing/SVGWriterTest.php
+++ b/tests/Writing/SVGWriterTest.php
@@ -5,14 +5,12 @@ namespace SVG;
 use SVG\Writing\SVGWriter;
 
 /**
+ * @covers \SVG\Writing\SVGWriter
+ *
  * @SuppressWarnings(PHPMD)
  */
 class SVGWriterTest extends \PHPUnit\Framework\TestCase
 {
-    // THE TESTS IN THIS CLASS DO NOT ADHERE TO THE STANDARD LAYOUT
-    // OF TESTING ONE CLASS METHOD PER TEST METHOD
-    // BECAUSE THE CLASS UNDER TEST IS A SINGLE-FEATURE CLASS
-
     private $xmlDeclaration = '<?xml version="1.0" encoding="utf-8"?>';
 
     public function testShouldIncludeXMLDeclaration()


### PR DESCRIPTION
The `@covers` annotation serves to limit coverage to the class under test. E.g. if the rasterizer is tested, but doing so requires creating a node, we do not want the test to add to the node's coverage.

Naturally, this addition will lead to project-wide coverage drops.