### PR TITLE
Change NodeRegistry::create to use string

### DIFF
--- a/src/Reading/NodeRegistry.php
+++ b/src/Reading/NodeRegistry.php
@@ -2,7 +2,6 @@
 
 namespace SVG\Reading;
 
-use SimpleXMLElement;
 use SVG\Nodes\SVGNode;
 use SVG\Nodes\SVGGenericNodeType;
 
@@ -87,21 +86,15 @@ class NodeRegistry
     );
 
     /**
-     * Instantiate a node class matching the given XML element type.
+     * Instantiate a node class matching the given type.
+     * If no such class exists, a generic one will be used.
      *
-     * Note that nothing is copied (attributes, namespaces etc.). This method
-     * creates an empty element of the respective type, nothing more.
-     *
-     * If no specific matching class exists, a generic class will be used.
-     *
-     * @param SimpleXMLElement $xml The XML element to serve as reference.
+     * @param string $type The node tag name ('svg', 'rect', 'title', etc.).
      *
      * @return SVGNode The node that was created.
      */
-    public static function create(SimpleXMLElement $xml)
+    public static function create($type)
     {
-        $type = $xml->getName();
-
         if (isset(self::$nodeTypes[$type])) {
             $nodeClass = self::$nodeTypes[$type];
             return new $nodeClass();

--- a/src/Reading/SVGReader.php
+++ b/src/Reading/SVGReader.php
@@ -171,7 +171,7 @@ class SVGReader
      */
     private function parseNode(SimpleXMLElement $xml, array $namespaces)
     {
-        $node = NodeRegistry::create($xml);
+        $node = NodeRegistry::create($xml->getName());
 
         // obtain array of namespaces that are declared directly on this node
         // TODO find solution for PHP < 5.4 (where the 2nd parameter was introduced)

--- a/tests/Reading/NodeRegistryTest.php
+++ b/tests/Reading/NodeRegistryTest.php
@@ -2,7 +2,6 @@
 
 namespace SVG;
 
-use SimpleXMLElement;
 use SVG\Reading\NodeRegistry;
 
 /**
@@ -14,17 +13,13 @@ class NodeRegistryTest extends \PHPUnit\Framework\TestCase
 {
     public function testShouldConstructKnownTypes()
     {
-        $xml = new SimpleXMLElement('<rect />');
-        $result = NodeRegistry::create($xml);
-
+        $result = NodeRegistry::create('rect');
         $this->assertInstanceOf('SVG\Nodes\Shapes\SVGRect', $result);
     }
 
     public function testShouldUseGenericTypeForOthers()
     {
-        $xml = new SimpleXMLElement('<div />');
-        $result = NodeRegistry::create($xml);
-
+        $result = NodeRegistry::create('div');
         $this->assertInstanceOf('SVG\Nodes\SVGGenericNodeType', $result);
     }
 }


### PR DESCRIPTION
The need to pass a `SimpleXMLElement` to `NodeRegistry::create` was eliminated with PR #106. This PR now simplifies the interface accordingly, to only require a string type instead of a full-blown element.