### PR TITLE
Move to GitHub Actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.4', '8.0']
+        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.4']
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,7 +33,7 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run PHPCS
-      run: vendor/bin/phpcs
+      run: phpcs
 
   test:
     needs: [ phpcs ]

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,101 @@
+name: CI
+
+on:
+- push
+- pull_request
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup PHP and PHPCS
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+        tools: phpcs
+        coverage: none
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run PHPCS
+      run: vendor/bin/phpcs
+
+  test:
+    needs: [ phpcs ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.4', '8.0']
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup PHP ${{ matrix.php-versions }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: gd, simplexml
+        coverage: none
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: vendor/bin/phpunit
+
+  coverage:
+    needs: [ test ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup PHP with tools
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.4
+        extensions: gd, simplexml
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run test suite with coverage
+      run: vendor/bin/phpunit --coverage-clover clover.xml
+
+    - name: Upload coverage
+      uses: paambaati/codeclimate-action@v2.7.5
+      env:
+        CC_TEST_REPORTER_ID: 7af3ff286959bfe9d7ad884fb72417c509e5d53149ba854a2d904aaa675ae13b
+      with:
+        coverageLocations: ${{github.workspace}}/clover.xml:clover

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,6 +50,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: gd, simplexml
         coverage: none
+        ini-values: auto_prepend_file="${{github.workspace}}/tests/bootstrap.php"
 
     - name: Cache Composer packages
       id: composer-cache

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 - 2020 Fabian Meyer
+Copyright (c) 2015 - 2021 Fabian Meyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # php-svg
 
-[![Build Status](https://travis-ci.com/meyfa/php-svg.svg?branch=master)](https://travis-ci.com/meyfa/php-svg)
+[![CI](https://github.com/meyfa/php-svg/actions/workflows/php.yml/badge.svg)](https://github.com/meyfa/php-svg/actions/workflows/php.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8f73468601a653aff0e8/maintainability)](https://codeclimate.com/github/meyfa/php-svg/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/8f73468601a653aff0e8/test_coverage)](https://codeclimate.com/github/meyfa/php-svg/test_coverage)
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file provides functions from older PHP versions that are no longer present in newer versions.
+ * This is needed because we are on PHPUnit 4.8 which was built long before some things were deprecated.
+ *
+ * Load this file before anything else is run, preferably through php.ini auto_prepend_file.
+ */
+
+if (!function_exists('each')) {
+    function each(&$array)
+    {
+        if (!is_array($array) && !is_object($array)) {
+            return null;
+        }
+        $key = key($array);
+        if ($key === null) {
+            return false;
+        }
+        $value = $array[$key];
+        next($array);
+        return array(
+            0 => $key,
+            'key' => $key,
+            1 => $value,
+            'value' => $value,
+        );
+    }
+}


### PR DESCRIPTION
Travis has become effectively unusable for Open Source. This PR moves us to GitHub Actions.

Note that I initially included testing on PHP v8.0, in addition to the existing versions. Unfortunately PHP-SVG is not yet compatible with PHP 8. Therefore tests failed, which meant that the new Actions workflow could not be observed in its entirety. As the workflow is the main contribution of this PR I decided to remove testing PHP 8 and will add it again later.