### PR TITLE
Add addFont() to SVGDocumentFragment

### DIFF
--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -83,21 +83,24 @@ class SVGDocumentFragment extends SVGNodeContainer
     }
 
     /**
-     * Add a font to text nodes.
+     * Add a font to text nodes that match given attributes.
      * @param string $fontPath The path of the font being added.
-     * @param string $nodeList The node list on where text nodes will be affected (whole document by default).
-     * @param string $fontFamily If specified, filter texts that are related to the given family.
+     * @param SVGText $textNode If specified, affects only text node that included in this node.
+     * @param string $fontFamily If specified, affects only texts that have this font family.
+     * @param string $fontWeight If specified, affects only texts that have this font weight.
+     * @param string $fontStyle If specified, affects only texts that have this text style.
      */
-    public function addFont(string $fontPath, ?DOMNodeList $nodeList = null, string $fontFamily = '') : void
+    public function addFont(string $fontPath, ?\SVG\Nodes\Texts\SVGText $textNode = null, string $fontFamily = '',
+                            string $fontWeight = '', string $fontStyle = '') : void
     {
-        $nodeList = $nodeList == null ? $this : $nodeList;
-        $this->fonts[$fontFamily] = $fontPath;
-
-        foreach ($nodeList->getElementsByTagName('text') as $textElmt) {
-            $font_family = $textElmt->getComputedStyle('font-family') ?? '';
-            if ($fontFamily == '' || $fontFamily == $font_family) {
-                $textElmt->setValue(preg_replace('/[\x00-\x1F\x7F]/u', '', $textElmt->getValue()));
-                $textElmt->setFont(new \SVG\Nodes\Structures\SVGFont($fontFamily, $fontPath));
+        $textNodes = $textNode == null ? $this->getElementsByTagName('text') : [$textNode];
+        foreach ($textNodes as $textNode) {
+            $nodeFontFamily = $textNode->getComputedStyle('font-family') ?? '';
+            $nodeFontWeight = $textNode->getComputedStyle('font-weight') ?? '';
+            $nodeFontStyle = $textNode->getComputedStyle('font-style') ?? '';
+            if ($nodeFontFamily == $fontFamily && $nodeFontWeight == $fontWeight && $nodeFontStyle == $fontStyle) {
+                $textNode->setValue(preg_replace('/[\x00-\x1F\x7F]/u', '', $textNode->getValue()));
+                $textNode->setFont(new \SVG\Nodes\Structures\SVGFont($fontFamily, $fontPath));
             }
         }
     }

--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -83,6 +83,26 @@ class SVGDocumentFragment extends SVGNodeContainer
     }
 
     /**
+     * Add a font to text nodes.
+     * @param string $fontPath The path of the font being added.
+     * @param string $nodeList The node list on where text nodes will be affected (whole document by default).
+     * @param string $fontFamily If specified, filter texts that are related to the given family.
+     */
+    public function addFont(string $fontPath, ?DOMNodeList $nodeList = null, string $fontFamily = '') : void
+    {
+        $nodeList = $nodeList == null ? $this : $nodeList;
+        $this->fonts[$fontFamily] = $fontPath;
+
+        foreach ($nodeList->getElementsByTagName('text') as $textElmt) {
+            $font_family = $textElmt->getComputedStyle('font-family') ?? '';
+            if ($fontFamily == '' || $fontFamily == $font_family) {
+                $textElmt->setValue(preg_replace('/[\x00-\x1F\x7F]/u', '', $textElmt->getValue()));
+                $textElmt->setFont(new \SVG\Nodes\Structures\SVGFont($fontFamily, $fontPath));
+            }
+        }
+    }
+
+    /**
      * @inheritdoc
      */
     public function getComputedStyle($name)


### PR DESCRIPTION
Add `addFont()` method to the `SVGDocumentFragment` class.

Related to #82 and #10.

## Usage

*Add a font to text nodes that match given attributes.*

Parameters:
- `string $fontPath` The path of the font being added.
- `SVGText $textNode` If specified, affects only text node that included in this node.
- `string $fontFamily` If specified, affects only texts that have this font family.
- `string $fontWeight` If specified, affects only texts that have this font weight.
- `string $fontStyle` If specified, affects only texts that have this text style.

## Example script

```php
<?php
require_once ("./vendor/autoload.php");
use SVG\SVG;

const FONTS_DIR = '/usr/share/fonts/truetype/ubuntu/';

$image = SVG::fromString('
<svg width="220" height="220">
	<rect x="0" y="0" width="100%" height="100%" fill="lightgray"/>
	<g font-size="15">
		<text y="20">no filter</text>
		<text y="60"  id="thin" fill="blue">thin</text>
		<text y="40"  class="condensed" stroke="white" stroke-width="1px">condensed</text>
		<text y="80"  font-family="monospace">monospace</text>
		<text y="100" font-weight="bold">bold</text>
		<text y="120" font-style="italic">italic</text>
		<text y="140" font-weight="bold" font-style="italic">bold italic</text>
		<text y="160" font-size="15" font-family="monospace" font-weight="bold">monospace bold</text>
		<text y="180" font-size="15" style="font-family: monospace; font-style: italic">monospace italic</text>
		<text y="200" font-size="15" style="font-family: monospace; font-weight: bold; font-style: italic">monospace bold italic</text>
	</g>
</svg>
');

$doc = $image->getDocument();

// no filter
$doc->addFont(FONTS_DIR . 'Ubuntu-R.ttf');

// filter on id
$doc->addFont(FONTS_DIR . 'Ubuntu-Th.ttf', $doc->getElementById('thin'));

// filter on class
foreach ($doc->getElementsByClassName('condensed') as $node) {
	$doc->addFont(FONTS_DIR . 'Ubuntu-C.ttf', $node);
}

// filter on font family
$doc->addFont(FONTS_DIR . 'UbuntuMono-R.ttf', null, 'monospace');

// // filter on text weight or/and style
$doc->addFont(FONTS_DIR . 'Ubuntu-B.ttf',  null, '', 'bold');
$doc->addFont(FONTS_DIR . 'Ubuntu-RI.ttf',  null, '', '', 'italic');
$doc->addFont(FONTS_DIR . 'Ubuntu-BI.ttf', null, '', 'bold', 'italic');

// filter on font family or/and weight or/and style
$doc->addFont(FONTS_DIR . 'UbuntuMono-B.ttf', null, 'monospace', 'bold');
$doc->addFont(FONTS_DIR . 'UbuntuMono-RI.ttf', null, 'monospace', '', 'italic');
$doc->addFont(FONTS_DIR . 'UbuntuMono-BI.ttf', null, 'monospace', 'bold', 'italic');

$raster = $image->toRasterImage($doc->getWidth(), $doc->getHeight());
imagepng($raster);
```

## Output

![out](https://user-images.githubusercontent.com/1665542/123164987-f0ba4980-d473-11eb-9421-9888a14272bd.png)

EDIT: update doc according to new usage in last commit.