### PR TITLE
Add stroke-dasharray support for EllipseRenderer (SVGCircle + SVGEllipse)

### DIFF
--- a/src/Nodes/Shapes/SVGCircle.php
+++ b/src/Nodes/Shapes/SVGCircle.php
@@ -107,6 +107,7 @@ class SVGCircle extends SVGNodeContainer
             'cy'    => $this->getCenterY(),
             'rx'    => $r,
             'ry'    => $r,
+            'dash'  => ($this->getStyle("stroke-dasharray") ? explode(" ", $this->getStyle("stroke-dasharray")) : [0, 0]),
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGEllipse.php
+++ b/src/Nodes/Shapes/SVGEllipse.php
@@ -128,6 +128,7 @@ class SVGEllipse extends SVGNodeContainer
             'cy'    => $this->getCenterY(),
             'rx'    => $this->getRadiusX(),
             'ry'    => $this->getRadiusY(),
+            'dash'  => ($this->getStyle("stroke-dasharray") ? explode(" ", $this->getStyle("stroke-dasharray")) : [0, 0]),
         ), $this);
     }
 }


### PR DESCRIPTION
Hi, this pull request adds support for stroke-dasharray on circles when creating raster image.

So something like this...

```php
$circle = new SVGCircle(50, 50, 80);
$circle->setStyle('fill', 'none');
$circle->setStyle('stroke', '#000000');
$circle->setStyle('stroke-width', '0.15');
$circle->setStyle('stroke-dasharray', '1.8 1.0');
```

...will now work in the rasterized image, too.