### PR TITLE
chore(ci): Configure test workflow to also run on PHP 8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,102 +1,102 @@
 name: CI
 
 on:
-- push
-- pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   phpcs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup PHP and PHPCS
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '7.4'
-        tools: phpcs
-        coverage: none
+      - name: Setup PHP and PHPCS
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: phpcs
+          coverage: none
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate --strict
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-    - name: Run PHPCS
-      run: phpcs
+      - name: Run PHPCS
+        run: phpcs
 
   test:
-    needs: [ phpcs ]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.4']
+        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.4', '8']
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup PHP ${{ matrix.php-versions }}
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        extensions: gd, simplexml
-        coverage: none
-        ini-values: auto_prepend_file="${{github.workspace}}/tests/bootstrap.php"
+      - name: Setup PHP ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: gd, simplexml
+          coverage: none
+          ini-values: auto_prepend_file="${{github.workspace}}/tests/bootstrap.php"
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-    - name: Run test suite
-      run: vendor/bin/phpunit
+      - name: Run test suite
+        run: vendor/bin/phpunit
 
   coverage:
-    needs: [ test ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup PHP with tools
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: 7.4
-        extensions: gd, simplexml
+      - name: Setup PHP with tools
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          extensions: gd, simplexml
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-    - name: Run test suite with coverage
-      run: vendor/bin/phpunit --coverage-clover clover.xml
+      - name: Run test suite with coverage
+        run: vendor/bin/phpunit --coverage-clover clover.xml
 
-    - name: Upload coverage
-      uses: paambaati/codeclimate-action@v2.7.5
-      env:
-        CC_TEST_REPORTER_ID: 7af3ff286959bfe9d7ad884fb72417c509e5d53149ba854a2d904aaa675ae13b
-      with:
-        coverageLocations: ${{github.workspace}}/clover.xml:clover
+      - name: Upload coverage
+        uses: paambaati/codeclimate-action@v3.0.0
+        env:
+          CC_TEST_REPORTER_ID: 7af3ff286959bfe9d7ad884fb72417c509e5d53149ba854a2d904aaa675ae13b
+        with:
+          coverageLocations: ${{github.workspace}}/clover.xml:clover

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 /vendor/
 /composer.lock
 /clover.xml
+.phpunit.result.cache
 .idea

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 - 2021 Fabian Meyer
+Copyright (c) 2015 - 2022 Fabian Meyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "meyfa/phpunit-assert-gd": "^1.1",
+        "meyfa/phpunit-assert-gd": "^1.2",
         "phpmd/phpmd" : "@stable"
     },
     "suggest": {

--- a/src/Rasterization/Renderers/ImageRenderer.php
+++ b/src/Rasterization/Renderers/ImageRenderer.php
@@ -33,7 +33,7 @@ class ImageRenderer extends Renderer
 
         $img = $this->loadImage($href, $width, $height);
 
-        if (!empty($img) && is_resource($img)) {
+        if (!empty($img) && (is_resource($img) || $img instanceof \GdImage)) {
             imagecopyresampled(
                 $image,         // dst
                 $img,           // src

--- a/tests/Rasterization/Renderers/MultiPassRendererTest.php
+++ b/tests/Rasterization/Renderers/MultiPassRendererTest.php
@@ -12,6 +12,18 @@ use SVG\Rasterization\Renderers\MultiPassRenderer;
  */
 class MultiPassRendererTest extends \PHPUnit\Framework\TestCase
 {
+    // helper function
+    private function isGdImage()
+    {
+        if (class_exists('\GdImage', false)) {
+            // PHP >=8: gd images are objects
+            return $this->isInstanceOf('\GdImage');
+        } else {
+            // PHP <8: gd images are resources
+            return $this->isType('resource');
+        }
+    }
+
     public function testRender()
     {
         $rast = new \SVG\Rasterization\SVGRasterizer(10, 20, null, 100, 200);
@@ -39,7 +51,7 @@ class MultiPassRendererTest extends \PHPUnit\Framework\TestCase
         $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
         $obj->method('prepareRenderParams')->willReturn($params);
         $obj->expects($this->once())->method('renderFill')->with(
-            $this->isType('resource'),
+            $this->isGdImage(),
             $this->identicalTo($params),
             $this->identicalTo(0xAAAAAA)
         );
@@ -58,7 +70,7 @@ class MultiPassRendererTest extends \PHPUnit\Framework\TestCase
         $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
         $obj->method('prepareRenderParams')->willReturn($params);
         $obj->expects($this->once())->method('renderStroke')->with(
-            $this->isType('resource'),
+            $this->isGdImage(),
             $this->identicalTo($params),
             $this->identicalTo(0xBBBBBB),
             $this->equalTo(20)

--- a/tests/Rasterization/SVGRasterizerTest.php
+++ b/tests/Rasterization/SVGRasterizerTest.php
@@ -177,9 +177,14 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
     {
         $obj = new SVGRasterizer(10, 20, array(), 100, 200);
 
-        // should be a gd resource
-        $this->assertTrue(is_resource($obj->getImage()));
-        $this->assertSame('gd', get_resource_type($obj->getImage()));
+        if (class_exists('\GdImage', false)) {
+            // PHP >=8: should be an image object
+            $this->assertInstanceOf('\GdImage', $obj->getImage());
+        } else {
+            // PHP <8: should be a gd resource
+            $this->assertTrue(is_resource($obj->getImage()));
+            $this->assertSame('gd', get_resource_type($obj->getImage()));
+        }
 
         // should have correct width and height
         $this->assertSame(100, imagesx($obj->getImage()));

--- a/tests/SVGTest.php
+++ b/tests/SVGTest.php
@@ -70,9 +70,14 @@ class SVGTest extends \PHPUnit\Framework\TestCase
         $image = new SVG(37, 42);
         $rasterImage = $image->toRasterImage(100, 200);
 
-        // should be a gd resource
-        $this->assertTrue(is_resource($rasterImage));
-        $this->assertSame('gd', get_resource_type($rasterImage));
+        if (class_exists('\GdImage', false)) {
+            // PHP >=8: should be an image object
+            $this->assertInstanceOf('\GdImage', $rasterImage);
+        } else {
+            // PHP <8: should be a gd resource
+            $this->assertTrue(is_resource($rasterImage));
+            $this->assertSame('gd', get_resource_type($rasterImage));
+        }
 
         // should have correct width and height
         $this->assertSame(100, imagesx($rasterImage));


### PR DESCRIPTION
Adds a job for PHP 8 to the test workflow. Also removes staggered execution
of the workflows, so that all of PHPCS, tests, and coverage can execute
immediately.

Dev dependency meyfa/phpunit-assert-gd is updated from v1.1 to v1.2 for
PHP 8 support.

ImageRenderer and a few test cases are adapted to treat `\GdImage` on PHP 8
the same as gd resources on earlier PHP versions.