### PR TITLE
feat: Implement path rendering that respects fill-rule! :)

### DIFF
--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -64,11 +64,9 @@ class SVGPath extends SVGNodeContainer
         $commands = $rasterizer->getPathParser()->parse($d);
         $subpaths = $rasterizer->getPathApproximator()->approximate($commands);
 
-        foreach ($subpaths as $subpath) {
-            $rasterizer->render('polygon', array(
-                'open'      => true,
-                'points'    => $subpath,
-            ), $this);
-        }
+        $rasterizer->render('path', array(
+            'segments'  => $subpaths,
+            'fill-rule' => strtolower(trim($this->getComputedStyle('fill-rule') ?: 'nonzero'))
+        ), $this);
     }
 }

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -130,15 +130,12 @@ class PathRenderer extends MultiPassRenderer
                         imageline($image, $prev->x, $scanline, $curr->x, $scanline, $color);
                     }
 
+                    // The original C++ code did some checking for whether a vertex was hit directly, and if so,
+                    // only incremented the winding number in certain cases.
+                    // I have found this to cause some problems and solve none, so I removed it.
+
                     // There are some weird cases when the ray hits a vertex directly, which we have to account for.
-                    $hitsMaxima = $scanline === $prev->minY ||
-                        $scanline === $prev->maxY ||
-                        $scanline === $curr->minY ||
-                        $scanline === $curr->maxY;
-                    $hitsVertex = $hitsMaxima && $prev->x === $curr->x;
-                    if (!$hitsVertex || $prev->inverseSlope * $curr->inverseSlope < 0) {
-                        $windingNumber += $evenOdd ? 1 : $curr->direction;
-                    }
+                    $windingNumber += $evenOdd ? 1 : $curr->direction;
                 }
 
                 // Finally, since the next step will look at the edges one pixel further up, move the $x property

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace SVG\Rasterization\Renderers;
+
+use SVG\Rasterization\SVGRasterizer;
+
+/**
+ * This renderer can draw pre-approximated paths, which are sets of line segments. These segments can potentially
+ * overlap, which is where this renderer improves on the simpler PolygonRenderer since it respects fill rules
+ * (nonzero or evenodd winding).
+ * The points are provided as arrays with 2 entries: 0 => x coord, 1 => y coord.
+ *
+ * Options:
+ * - array[][] segments: the segments, which are arrays of coordinate tuples (i.e., array of array of array of float)
+ */
+class PathRenderer extends MultiPassRenderer
+{
+    /**
+     * @inheritdoc
+     */
+    protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
+    {
+        $scaleX = $rasterizer->getScaleX();
+        $scaleY = $rasterizer->getScaleY();
+
+        $offsetX = $rasterizer->getOffsetX();
+        $offsetY = $rasterizer->getOffsetY();
+
+        $segments = array();
+        foreach ($options['segments'] as $segment) {
+            $points = array();
+            foreach ($segment as $point) {
+                $points[] = $point[0] * $scaleX + $offsetX;
+                $points[] = $point[1] * $scaleY + $offsetY;
+            }
+            $segments[] = $points;
+        }
+
+        return array(
+            'segments'  => $segments,
+            'fill-rule' => $options['fill-rule'],
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function renderFill($image, array $params, $color)
+    {
+        if (empty($params['segments']) || count($params['segments'][0]) < 2) {
+            return;
+        }
+
+        imagesetthickness($image, 1);
+
+        // whether to use the evenodd rule (vs. nonzero winding)
+        $evenOdd = $params['fill-rule'] === 'evenodd';
+
+        /*
+         * The following algorithm is roughly adapted from FillPathImplementation.h of the SerenityOS project, commit
+         * 5a2e7d30ce2f673cd84073c1e96287329fe310db. The C++ implementation is Copyright (c) 2021 Ali Mohammad Pur.
+         * SerenityOS is licensed under the BSD 2-Clause license.
+         */
+
+        // Get an array of all edges contained in all of the subpaths.
+        // Since a subpath can intersect with itself just as it can intersect with other subpaths,
+        // there is no need to remember to which subpath an edge belongs.
+        $edges = array();
+        $minY = $params['segments'][0][1];
+        foreach ($params['segments'] as $points) {
+            for ($i = 0, $n = count($points); $i < $n; $i += 2) {
+                $x1 = $points[$i];
+                $y1 = $points[$i + 1];
+                // the last vertex gets connected back to the first vertex for a complete loop
+                $x2 = $points[($i + 2) % $n];
+                $y2 = $points[($i + 3) % $n];
+                $edge = new PathRendererEdge($x1, $y1, $x2, $y2);
+                $minY = min($minY, $edge->minY);
+                $edges[] = $edge;
+            }
+        }
+        // Sort the edges by their maximum y value, descending (i.e., edges that extend further down are sorted first).
+        usort($edges, array('SVG\Rasterization\Renderers\PathRendererEdge', 'compareMaxY'));
+        // Now the maxY of the entire path is just the maxY of the edge sorted first.
+        // Since there is no way to know which edge has the minY, we cannot do the same for that and have to compute
+        // it during the loop instead.
+        $maxY = $edges[0]->maxY;
+
+        // Not all edges are relevant the entire time. This stores only the ones that extend between y coordinates
+        // that include the current scanline.
+        $activeEdges = array();
+        // The index into $edges of the last edge that was added to $activeEdges.
+        $lastActiveEdge = 0;
+
+        // Loop over the path area from bottom to top, so that we can make good use of the sort order of $edges.
+        for ($scanline = $maxY; $scanline >= $minY; --$scanline) {
+            // An edge becomes irrelevant when the scanline is higher up than the edge's minY.
+            $activeEdges = array_values(array_filter($activeEdges, function ($edge) use ($scanline) {
+                return $scanline > $edge->minY;
+            }));
+
+            // An edge becomes relevant when its y range starts to include $scanline.
+            for ($i = $lastActiveEdge, $n = count($edges); $i < $n; ++$i) {
+                $edge = $edges[$i];
+                // Since $edges is sorted by maxY, if this is true, there cannot be any more edges that match.
+                if ($edge->maxY < $scanline) {
+                    break;
+                }
+                if ($edge->minY < $scanline) {
+                    $activeEdges[] = $edge;
+                }
+                ++$lastActiveEdge;
+            }
+
+            if (!empty($activeEdges)) {
+                // Now sort the active edges from rightmost to leftmost (i.e., by x descending).
+                usort($activeEdges, array('SVG\Rasterization\Renderers\PathRendererEdge', 'compareX'));
+
+                $windingNumber = $evenOdd ? 0 : $activeEdges[0]->direction;
+
+                // Look at entire regions between neighboring edges, since each pixel in a region will have the same
+                // fill as all the others. Start with the region between the rightmost edge and the one to the left of
+                // it, then go to the region left of that, etc.
+                for ($i = 1, $n = count($activeEdges); $i < $n; ++$i) {
+                    $prev = $activeEdges[$i - 1];
+                    $curr = $activeEdges[$i];
+
+                    if ($evenOdd ? ($windingNumber % 2 === 0) : ($windingNumber !== 0)) {
+                        // This section of the scanline is inside.
+                        imageline($image, $prev->x, $scanline, $curr->x, $scanline, $color);
+                    }
+
+                    // There are some weird cases when the ray hits a vertex directly, which we have to account for.
+                    $hitsMaxima = $scanline === $prev->minY ||
+                        $scanline === $prev->maxY ||
+                        $scanline === $curr->minY ||
+                        $scanline === $curr->maxY;
+                    $hitsVertex = $hitsMaxima && $prev->x === $curr->x;
+                    if (!$hitsVertex || $prev->inverseSlope * $curr->inverseSlope < 0) {
+                        $windingNumber += $evenOdd ? 1 : $curr->direction;
+                    }
+                }
+
+                // Finally, since the next step will look at the edges one pixel further up, move the $x property
+                // by the inverse slope to obtain the x coordinate at that new height, i.e. slide the ray intersection
+                // point along the edge.
+                foreach ($activeEdges as $edge) {
+                    $edge->x -= $edge->inverseSlope;
+                }
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function renderStroke($image, array $params, $color, $strokeWidth)
+    {
+        imagesetthickness($image, $strokeWidth);
+
+        foreach ($params['segments'] as $points) {
+            $this->renderStrokeOpen($image, $points, $color);
+        }
+    }
+
+    private function renderStrokeOpen($image, array $points, $color)
+    {
+        // This is just the same as for polylines.
+
+        $px = $points[0];
+        $py = $points[1];
+
+        for ($i = 2, $n = count($points); $i < $n; $i += 2) {
+            $x = $points[$i];
+            $y = $points[$i + 1];
+            imageline($image, $px, $py, $x, $y, $color);
+            $px = $x;
+            $py = $y;
+        }
+    }
+}

--- a/src/Rasterization/Renderers/PathRendererEdge.php
+++ b/src/Rasterization/Renderers/PathRendererEdge.php
@@ -62,7 +62,7 @@ class PathRendererEdge
     {
         if ($a->maxY < $b->maxY) {
             return 1;
-        } else if ($a->maxY > $b->maxY) {
+        } elseif ($a->maxY > $b->maxY) {
             return -1;
         }
         return 0;
@@ -79,7 +79,7 @@ class PathRendererEdge
     {
         if ($a->x < $b->x) {
             return 1;
-        } else if ($a->x > $b->x) {
+        } elseif ($a->x > $b->x) {
             return -1;
         }
         return 0;

--- a/src/Rasterization/Renderers/PathRendererEdge.php
+++ b/src/Rasterization/Renderers/PathRendererEdge.php
@@ -47,7 +47,8 @@ class PathRendererEdge
         $this->maxY = max($y1, $y2);
 
         $this->direction = $y1 > $y2 ? -1 : 1;
-        $this->inverseSlope = $y1 === $y2 ? 0 : ($x1 - $x2) / ($y1 - $y2);
+        // NOTE: do not compare ($y1 === $y2) strictly, because in PHP, (4.0 === 4) is false!
+        $this->inverseSlope = $y1 == $y2 ? 0.0 : ($x1 - $x2) / ($y1 - $y2);
         $this->x = $y1 > $y2 ? $x1 : $x2;
     }
 

--- a/src/Rasterization/Renderers/PathRendererEdge.php
+++ b/src/Rasterization/Renderers/PathRendererEdge.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SVG\Rasterization\Renderers;
+
+/**
+ * A mutable data structure used by the PathRenderer during scanline fill.
+ */
+class PathRendererEdge
+{
+    /**
+     * @var float The smaller of the two y values.
+     */
+    public $minY;
+
+    /**
+     * @var float The larger of the two y values.
+     */
+    public $maxY;
+
+    /**
+     * @var int The vertical winding direction of this edge, 1 if top to bottom, -1 if bottom to top.
+     */
+    public $direction;
+
+    /**
+     * @var float Delta x over delta y of this edge, or 0 if the edge is fully horizontal (dy === 0).
+     */
+    public $inverseSlope;
+
+    /**
+     * @var float Initially, the x coordinate belonging to the maxY value, but slides upwards during scanning.
+     */
+    public $x;
+
+    /**
+     * Construct a new edge object from the two end points. The order of points is important here,
+     * for computing the edge direction.
+     *
+     * @param $x1 float First point X.
+     * @param $y1 float First point Y.
+     * @param $x2 float Second point X.
+     * @param $y2 float Second point Y.
+     */
+    public function __construct($x1, $y1, $x2, $y2)
+    {
+        $this->minY = min($y1, $y2);
+        $this->maxY = max($y1, $y2);
+
+        $this->direction = $y1 > $y2 ? -1 : 1;
+        $this->inverseSlope = $y1 === $y2 ? 0 : ($x1 - $x2) / ($y1 - $y2);
+        $this->x = $y1 > $y2 ? $x1 : $x2;
+    }
+
+    /**
+     * Comparator function for sorting edges by their $maxY descending.
+     *
+     * @param $a self The first edge.
+     * @param $b self The second edge.
+     * @return int Comparison result.
+     */
+    public static function compareMaxY($a, $b)
+    {
+        if ($a->maxY < $b->maxY) {
+            return 1;
+        } else if ($a->maxY > $b->maxY) {
+            return -1;
+        }
+        return 0;
+    }
+
+    /**
+     * Comparator function for sorting edges by their $x descending.
+     *
+     * @param $a self The first edge.
+     * @param $b self The second edge.
+     * @return int Comparison result.
+     */
+    public static function compareX($a, $b)
+    {
+        if ($a->x < $b->x) {
+            return 1;
+        } else if ($a->x > $b->x) {
+            return -1;
+        }
+        return 0;
+    }
+}

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -135,6 +135,7 @@ class SVGRasterizer
             'line'      => new Renderers\LineRenderer(),
             'ellipse'   => new Renderers\EllipseRenderer(),
             'polygon'   => new Renderers\PolygonRenderer(),
+            'path'      => new Renderers\PathRenderer(),
             'image'     => new Renderers\ImageRenderer(),
             'text'      => new Renderers\TextRenderer(),
         );

--- a/tests/Nodes/Shapes/SVGPathTest.php
+++ b/tests/Nodes/Shapes/SVGPathTest.php
@@ -107,34 +107,23 @@ class SVGPathTest extends \PHPUnit\Framework\TestCase
             ->willReturn($pathApproximator);
 
         // should call path parser with description attribute
-        $pathParser->expects($this->any())->method('parse')->with(
+        $pathParser->expects($this->once())->method('parse')->with(
             $this->identicalTo(self::$sampleDescription)
         )->willReturn(self::$sampleParse);
 
         // should call path approximator with parser's return value
-        $pathApproximator->expects($this->any())->method('approximate')->with(
+        $pathApproximator->expects($this->once())->method('approximate')->with(
             $this->identicalTo(self::$sampleParse)
         )->willReturn(self::$sampleApproximate);
 
         // should call image renderer with correct options
-        // (once for every subpath)
-        $rast->expects($this->exactly(2))->method('render')->withConsecutive(
-            array(
-                $this->identicalTo('polygon'),
-                $this->identicalTo(array(
-                    'open' => true,
-                    'points' => self::$sampleApproximate[0],
-                )),
-                $this->identicalTo($obj)
-            ),
-            array(
-                $this->identicalTo('polygon'),
-                $this->identicalTo(array(
-                    'open' => true,
-                    'points' => self::$sampleApproximate[1],
-                )),
-                $this->identicalTo($obj)
-            )
+        $rast->expects($this->once())->method('render')->with(
+            $this->identicalTo('path'),
+            $this->identicalTo(array(
+                'segments' => self::$sampleApproximate,
+                'fill-rule' => 'nonzero',
+            )),
+            $this->identicalTo($obj)
         );
         $obj->rasterize($rast);
 


### PR DESCRIPTION
Fixes #28. The time has finally come that I understand how scanline
algorithms work and was able to implement this by referencing an
existing implementation in the SerenityOS path renderer.

I did a lot of work to adapt that code to PHP and get it to perform as
well as possible. Note that for some images rendering still takes ages,
but that is not due to PathRenderer, rather the BezierApproximator does
not yet take scale into account and oftentimes generates curves with
waaaaay too many segments. I have done benchmarks and this rendering
algorithm is insanely efficient for what it does. If anything can be
optimized, it is probably the looping over and transforming of each
point during preparation.