### PR TITLE
fix: Round the strokeWidth when outlining shapes in renderers

### DIFF
--- a/src/Rasterization/Renderers/EllipseRenderer.php
+++ b/src/Rasterization/Renderers/EllipseRenderer.php
@@ -41,7 +41,7 @@ class EllipseRenderer extends MultiPassRenderer
      */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
-        imagesetthickness($image, $strokeWidth);
+        imagesetthickness($image, round($strokeWidth));
 
         $width = $params['width'];
         if ($width % 2 === 0) {

--- a/src/Rasterization/Renderers/LineRenderer.php
+++ b/src/Rasterization/Renderers/LineRenderer.php
@@ -44,7 +44,7 @@ class LineRenderer extends MultiPassRenderer
      */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
-        imagesetthickness($image, $strokeWidth);
+        imagesetthickness($image, round($strokeWidth));
         imageline($image, $params['x1'], $params['y1'], $params['x2'], $params['y2'], $color);
     }
 }

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -4,7 +4,6 @@ namespace SVG\Rasterization\Renderers;
 
 use SVG\Nodes\SVGNode;
 use SVG\Rasterization\SVGRasterizer;
-use SVG\Utilities\Units\Length;
 use SVG\Utilities\Colors\Color;
 
 /**
@@ -127,9 +126,8 @@ abstract class MultiPassRenderer extends Renderer
         }
 
         $paintOrder = array_intersect(explode(' ', $paintOrder), $defaultOrder);
-        $paintOrder = array_merge($paintOrder, array_diff($defaultOrder, $paintOrder));
 
-        return $paintOrder;
+        return array_merge($paintOrder, array_diff($defaultOrder, $paintOrder));
     }
 
     /**

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -153,7 +153,7 @@ class PathRenderer extends MultiPassRenderer
      */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
-        imagesetthickness($image, $strokeWidth);
+        imagesetthickness($image, round($strokeWidth));
 
         foreach ($params['segments'] as $points) {
             $this->renderStrokeOpen($image, $points, $color);

--- a/src/Rasterization/Renderers/PolygonRenderer.php
+++ b/src/Rasterization/Renderers/PolygonRenderer.php
@@ -57,7 +57,7 @@ class PolygonRenderer extends MultiPassRenderer
      */
     protected function renderStroke($image, array $params, $color, $strokeWidth)
     {
-        imagesetthickness($image, $strokeWidth);
+        imagesetthickness($image, round($strokeWidth));
 
         if ($params['open']) {
             $this->renderStrokeOpen($image, $params['points'], $color);

--- a/src/Rasterization/Renderers/RectRenderer.php
+++ b/src/Rasterization/Renderers/RectRenderer.php
@@ -136,7 +136,7 @@ class RectRenderer extends MultiPassRenderer
             return;
         }
 
-        imagesetthickness($image, $strokeWidth);
+        imagesetthickness($image, round($strokeWidth));
 
         if ($params['rx'] !== 0 || $params['ry'] !== 0) {
             $this->renderStrokeRounded($image, $params, $color, $strokeWidth);

--- a/src/Rasterization/Renderers/Renderer.php
+++ b/src/Rasterization/Renderers/Renderer.php
@@ -5,14 +5,13 @@ namespace SVG\Rasterization\Renderers;
 use SVG\Nodes\SVGNode;
 use SVG\Rasterization\SVGRasterizer;
 use SVG\Utilities\Units\Length;
-use SVG\Utilities\Colors\Color;
 
 /**
  * This is the base class for all shape renderer instances.
  *
  * It contains the method `render(SVGRasterizer, array, SVGNode)` that is used
  * to invoke a drawing operation.
- * Subclasses generally require a special asociative options array to be passed
+ * Subclasses generally require a special associative options array to be passed
  * to this render method; see their docs for a list of things to provide.
  */
 abstract class Renderer


### PR DESCRIPTION
PHP simply cuts off any decimal part of the stroke width. I have just
come across an example where the stroke width that was expected to be
rendered was 1.99999997 pixels, but of course that meant only 1 pixel
wide was actually rendered. With this change, that problem should be
gone. Until we have antialiasing, it's probably fine to assume any
stroke width of greater than or equal to 1.5px should become 2px.