### PR TITLE
feat: Add normalized diagonal getters to SVGRasterizer

### DIFF
--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -216,6 +216,27 @@ class SVGRasterizer
     }
 
     /**
+     * Obtain the normalized diagonal of the SVG viewport. The normalized diagonal is to be used as the reference size
+     * for percentages that don't strictly refer to the horizontal or vertical axis. Examples of such values are
+     * a circle's radius attribute or the stroke-width.
+     *
+     * This is computed by the formula <code>hypot(documentWidth, documentHeight)/sqrt(2)</code>.
+     *
+     * @return float The normalized diagonal length.
+     */
+    public function getNormalizedDiagonal()
+    {
+        // https://svgwg.org/svg2-draft/coords.html#Units
+
+        // For any other length value expressed as a percentage of the SVG viewport, the percentage must be calculated
+        // as a percentage of the normalized diagonal of the ‘viewBox’ applied to that viewport. If no ‘viewBox’ is
+        // specified, then the normalized diagonal of the SVG viewport must be used. The normalized diagonal length must
+        // be calculated with sqrt((width)**2 + (height)**2)/sqrt(2).
+
+        return hypot($this->docWidth, $this->docHeight) / M_SQRT2;
+    }
+
+    /**
      * @return int The output image width, in pixels.
      */
     public function getWidth()
@@ -245,6 +266,17 @@ class SVGRasterizer
     public function getScaleY()
     {
         return $this->scaleY;
+    }
+
+    /**
+     * Determine the normalized diagonal scaling factor. This is the factor that should be used when scaling percentages
+     * for properties that are not strictly horizontal or strictly vertical, such as stroke-width.
+     *
+     * @return float The scaling factor of the view diagonal.
+     */
+    public function getDiagonalScale()
+    {
+        return hypot($this->scaleX, $this->scaleY) / M_SQRT2;
     }
 
     /**

--- a/tests/Rasterization/SVGRasterizerTest.php
+++ b/tests/Rasterization/SVGRasterizerTest.php
@@ -69,6 +69,17 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::getNormalizedDiagonal
+     */
+    public function testGetNormalizedDiagonal()
+    {
+        // should return the correct length
+        $obj = new SVGRasterizer('50%', '50%', null, 100, 200);
+        $this->assertEquals(79.05, $obj->getNormalizedDiagonal(), null, 0.01);
+        imagedestroy($obj->getImage());
+    }
+
+    /**
      * @covers ::getWidth
      */
     public function testGetWidth()
@@ -119,6 +130,22 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         // should use document dimension when viewBox unavailable
         $obj = new SVGRasterizer(10, 20, array(), 100, 200);
         $this->assertEquals(10, $obj->getScaleY());
+        imagedestroy($obj->getImage());
+    }
+
+    /**
+     * @covers ::getDiagonalScale
+     */
+    public function testGetDiagonalScale()
+    {
+        // should use viewBox dimension when available
+        $obj = new SVGRasterizer(10, 20, array(37, 42, 25, 100), 100, 200);
+        $this->assertEquals(3.16, $obj->getDiagonalScale(), null, 0.01);
+        imagedestroy($obj->getImage());
+
+        // should use document dimension when viewBox unavailable
+        $obj = new SVGRasterizer(10, 20, array(), 100, 300);
+        $this->assertEquals(12.74, $obj->getDiagonalScale(), '', 0.01);
         imagedestroy($obj->getImage());
     }
 


### PR DESCRIPTION
These will be useful for spec-compliant computation of length
percentages, for attributes that do not refer to a specific axis.
Currently, we are using the document width as reference for everything.