### PR TITLE
tests: Ensure Length::convert() with null input returns null

### DIFF
--- a/src/Utilities/Units/Length.php
+++ b/src/Utilities/Units/Length.php
@@ -8,10 +8,10 @@ final class Length
      * Converts any valid SVG length string into an absolute pixel length,
      * using the given canvas width as reference for percentages.
      *
-     * If the string does not denote a valid length unit, null is returned.
+     * If the input is null or is a string that does not denote a valid length unit, null is returned.
      *
-     * @param string $unit       The SVG length string to convert.
-     * @param float  $viewLength The canvas width to use as reference length.
+     * @param string|null $unit       The SVG length string to convert.
+     * @param float       $viewLength The canvas width to use as reference length.
      *
      * @return float|null The absolute pixel number the given string denotes.
      */

--- a/tests/Utilities/Units/LengthTest.php
+++ b/tests/Utilities/Units/LengthTest.php
@@ -31,5 +31,6 @@ class LengthTest extends \PHPUnit\Framework\TestCase
         // illegal: missing number
         $this->assertNull(Length::convert('px', 100));
         $this->assertNull(Length::convert('', 100));
+        $this->assertNull(Length::convert(null, 100));
     }
 }


### PR DESCRIPTION
This behavior is very useful for converting length attributes that are
optional. We should ensure it doesn't go away, so that callers can
depend on it.