### PR TITLE
refactor: Convert lengths to pixels outside of renderers

### DIFF
--- a/src/Nodes/Embedded/SVGImage.php
+++ b/src/Nodes/Embedded/SVGImage.php
@@ -5,6 +5,7 @@ namespace SVG\Nodes\Embedded;
 use RuntimeException;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Utilities\Units\Length;
 
 /**
  * Represents the SVG tag 'image'.
@@ -206,10 +207,10 @@ class SVGImage extends SVGNodeContainer
 
         $rasterizer->render('image', array(
             'href'      => $this->getHref(),
-            'x'         => $this->getX(),
-            'y'         => $this->getY(),
-            'width'     => $this->getWidth(),
-            'height'    => $this->getHeight(),
+            'x'         => Length::convert($this->getX(), $rasterizer->getDocumentWidth()),
+            'y'         => Length::convert($this->getY(), $rasterizer->getDocumentHeight()),
+            'width'     => Length::convert($this->getWidth(), $rasterizer->getDocumentWidth()),
+            'height'    => Length::convert($this->getHeight(), $rasterizer->getDocumentHeight()),
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGCircle.php
+++ b/src/Nodes/Shapes/SVGCircle.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Utilities\Units\Length;
 
 /**
  * Represents the SVG tag 'circle'.
@@ -101,10 +102,13 @@ class SVGCircle extends SVGNodeContainer
             return;
         }
 
-        $r = $this->getRadius();
+        // https://svgwg.org/svg2-draft/geometry.html#R
+        // Percentages: refer to the normalized diagonal of the current SVG viewport
+        $r = Length::convert($this->getRadius(), $rasterizer->getNormalizedDiagonal());
+
         $rasterizer->render('ellipse', array(
-            'cx'    => $this->getCenterX(),
-            'cy'    => $this->getCenterY(),
+            'cx'    => Length::convert($this->getCenterX(), $rasterizer->getDocumentWidth()),
+            'cy'    => Length::convert($this->getCenterY(), $rasterizer->getDocumentHeight()),
             'rx'    => $r,
             'ry'    => $r,
         ), $this);

--- a/src/Nodes/Shapes/SVGEllipse.php
+++ b/src/Nodes/Shapes/SVGEllipse.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Utilities\Units\Length;
 
 /**
  * Represents the SVG tag 'ellipse'.
@@ -124,10 +125,10 @@ class SVGEllipse extends SVGNodeContainer
         }
 
         $rasterizer->render('ellipse', array(
-            'cx'    => $this->getCenterX(),
-            'cy'    => $this->getCenterY(),
-            'rx'    => $this->getRadiusX(),
-            'ry'    => $this->getRadiusY(),
+            'cx'    => Length::convert($this->getCenterX(), $rasterizer->getDocumentWidth()),
+            'cy'    => Length::convert($this->getCenterY(), $rasterizer->getDocumentHeight()),
+            'rx'    => Length::convert($this->getRadiusX(), $rasterizer->getDocumentWidth()),
+            'ry'    => Length::convert($this->getRadiusY(), $rasterizer->getDocumentHeight()),
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGLine.php
+++ b/src/Nodes/Shapes/SVGLine.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Utilities\Units\Length;
 
 /**
  * Represents the SVG tag 'line'.
@@ -124,10 +125,10 @@ class SVGLine extends SVGNodeContainer
         }
 
         $rasterizer->render('line', array(
-            'x1'    => $this->getX1(),
-            'y1'    => $this->getY1(),
-            'x2'    => $this->getX2(),
-            'y2'    => $this->getY2(),
+            'x1'    => Length::convert($this->getX1(), $rasterizer->getDocumentWidth()),
+            'y1'    => Length::convert($this->getY1(), $rasterizer->getDocumentHeight()),
+            'x2'    => Length::convert($this->getX2(), $rasterizer->getDocumentWidth()),
+            'y2'    => Length::convert($this->getY2(), $rasterizer->getDocumentHeight()),
         ), $this);
     }
 }

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Utilities\Units\Length;
 
 /**
  * Represents the SVG tag 'rect'.
@@ -160,12 +161,12 @@ class SVGRect extends SVGNodeContainer
         }
 
         $rasterizer->render('rect', array(
-            'x'         => $this->getX(),
-            'y'         => $this->getY(),
-            'width'     => $this->getWidth(),
-            'height'    => $this->getHeight(),
-            'rx'        => $this->getRX(),
-            'ry'        => $this->getRY(),
+            'x'         => Length::convert($this->getX(), $rasterizer->getDocumentWidth()),
+            'y'         => Length::convert($this->getY(), $rasterizer->getDocumentHeight()),
+            'width'     => Length::convert($this->getWidth(), $rasterizer->getDocumentWidth()),
+            'height'    => Length::convert($this->getHeight(), $rasterizer->getDocumentHeight()),
+            'rx'        => Length::convert($this->getRX(), $rasterizer->getDocumentWidth()),
+            'ry'        => Length::convert($this->getRY(), $rasterizer->getDocumentHeight()),
         ), $this);
     }
 }

--- a/src/Nodes/Texts/SVGText.php
+++ b/src/Nodes/Texts/SVGText.php
@@ -5,6 +5,7 @@ namespace SVG\Nodes\Texts;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Nodes\Structures\SVGFont;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Utilities\Units\Length;
 
 /**
  * Represents the SVG tag 'text'.
@@ -91,10 +92,16 @@ class SVGText extends SVGNodeContainer
             return;
         }
 
+        // TODO: support percentage font sizes
+        //       https://www.w3.org/TR/SVG11/text.html#FontSizeProperty
+        //       "Percentages: refer to parent element's font size"
+        // For now, assume the standard font size of 16px as reference size
+        $fontSize = Length::convert($this->getComputedStyle('font-size'), 16);
+
         $rasterizer->render('text', array(
-            'x'         => $this->getAttribute('x'),
-            'y'         => $this->getAttribute('y'),
-            'size'      => $this->getComputedStyle('font-size'),
+            'x'         => Length::convert($this->getAttribute('x'), $rasterizer->getDocumentWidth()),
+            'y'         => Length::convert($this->getAttribute('y'), $rasterizer->getDocumentHeight()),
+            'size'      => $fontSize,
             'anchor'    => $this->getComputedStyle('text-anchor'),
             'text'      => $this->getValue(),
             'font_path' => $this->font->getFontPath(),

--- a/src/Rasterization/Renderers/EllipseRenderer.php
+++ b/src/Rasterization/Renderers/EllipseRenderer.php
@@ -21,10 +21,10 @@ class EllipseRenderer extends MultiPassRenderer
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
         return array(
-            'cx'        => self::prepareLengthX($options['cx'], $rasterizer) + $rasterizer->getOffsetX(),
-            'cy'        => self::prepareLengthY($options['cy'], $rasterizer) + $rasterizer->getOffsetY(),
-            'width'     => self::prepareLengthX($options['rx'], $rasterizer) * 2,
-            'height'    => self::prepareLengthY($options['ry'], $rasterizer) * 2,
+            'cx'        => $options['cx'] * $rasterizer->getScaleX() + $rasterizer->getOffsetX(),
+            'cy'        => $options['cy'] * $rasterizer->getScaleY() + $rasterizer->getOffsetY(),
+            'width'     => $options['rx'] * $rasterizer->getScaleX() * 2,
+            'height'    => $options['ry'] * $rasterizer->getScaleY() * 2,
         );
     }
 

--- a/src/Rasterization/Renderers/ImageRenderer.php
+++ b/src/Rasterization/Renderers/ImageRenderer.php
@@ -23,15 +23,14 @@ class ImageRenderer extends Renderer
      */
     public function render(SVGRasterizer $rasterizer, array $options, SVGNode $context)
     {
-        $href   = $options['href'];
-        $x      = self::prepareLengthX($options['x'], $rasterizer) + $rasterizer->getOffsetX();
-        $y      = self::prepareLengthY($options['y'], $rasterizer) + $rasterizer->getOffsetY();
-        $width  = self::prepareLengthX($options['width'], $rasterizer);
-        $height = self::prepareLengthY($options['height'], $rasterizer);
+        $x      = $options['x'] * $rasterizer->getScaleX() + $rasterizer->getOffsetX();
+        $y      = $options['y'] * $rasterizer->getScaleY() + $rasterizer->getOffsetY();
+        $width  = $options['width'] * $rasterizer->getScaleY();
+        $height = $options['height'] * $rasterizer->getScaleX();
 
         $image = $rasterizer->getImage();
 
-        $img = $this->loadImage($href, $width, $height);
+        $img = $this->loadImage($options['href'], $width, $height);
 
         if (!empty($img) && (is_resource($img) || $img instanceof \GdImage)) {
             imagecopyresampled(

--- a/src/Rasterization/Renderers/LineRenderer.php
+++ b/src/Rasterization/Renderers/LineRenderer.php
@@ -24,10 +24,10 @@ class LineRenderer extends MultiPassRenderer
         $offsetY = $rasterizer->getOffsetY();
 
         return array(
-            'x1' => self::prepareLengthX($options['x1'], $rasterizer) + $offsetX,
-            'y1' => self::prepareLengthY($options['y1'], $rasterizer) + $offsetY,
-            'x2' => self::prepareLengthX($options['x2'], $rasterizer) + $offsetX,
-            'y2' => self::prepareLengthY($options['y2'], $rasterizer) + $offsetY,
+            'x1' => $options['x1'] * $rasterizer->getScaleX() + $offsetX,
+            'y1' => $options['y1'] * $rasterizer->getScaleY() + $offsetY,
+            'x2' => $options['x2'] * $rasterizer->getScaleX() + $offsetX,
+            'y2' => $options['y2'] * $rasterizer->getScaleY() + $offsetY,
         );
     }
 

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -40,11 +40,15 @@ abstract class MultiPassRenderer extends Renderer
     {
         $stroke = $context->getComputedStyle('stroke');
         if (isset($stroke) && $stroke !== 'none') {
-            $stroke      = self::prepareColor($stroke, $context);
-            $strokeWidth = Length::convert($context->getComputedStyle('stroke-width'), $rasterizer->getNormalizedDiagonal());
+            $stroke = self::prepareColor($stroke, $context);
+
+            $strokeWidth = $context->getComputedStyle('stroke-width');
+            $strokeWidth = Length::convert($strokeWidth, $rasterizer->getNormalizedDiagonal());
             $strokeWidth = $strokeWidth * $rasterizer->getDiagonalScale();
 
-            $this->renderStroke($rasterizer->getImage(), $params, $stroke, $strokeWidth);
+            if ($strokeWidth > 0) {
+                $this->renderStroke($rasterizer->getImage(), $params, $stroke, $strokeWidth);
+            }
         }
     }
 

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -5,6 +5,7 @@ namespace SVG\Rasterization\Renderers;
 use SVG\Nodes\SVGNode;
 use SVG\Rasterization\SVGRasterizer;
 use SVG\Utilities\Colors\Color;
+use SVG\Utilities\Units\Length;
 
 /**
  * This extends the Renderer class to offer features for multi-pass rendering
@@ -40,8 +41,8 @@ abstract class MultiPassRenderer extends Renderer
         $stroke = $context->getComputedStyle('stroke');
         if (isset($stroke) && $stroke !== 'none') {
             $stroke      = self::prepareColor($stroke, $context);
-            $strokeWidth = $context->getComputedStyle('stroke-width');
-            $strokeWidth = self::prepareLengthX($strokeWidth, $rasterizer);
+            $strokeWidth = Length::convert($context->getComputedStyle('stroke-width'), $rasterizer->getNormalizedDiagonal());
+            $strokeWidth = $strokeWidth * $rasterizer->getDiagonalScale();
 
             $this->renderStroke($rasterizer->getImage(), $params, $stroke, $strokeWidth);
         }

--- a/src/Rasterization/Renderers/RectRenderer.php
+++ b/src/Rasterization/Renderers/RectRenderer.php
@@ -22,29 +22,29 @@ class RectRenderer extends MultiPassRenderer
      */
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
-        $w  = self::prepareLengthX($options['width'], $rasterizer);
-        $h  = self::prepareLengthY($options['height'], $rasterizer);
+        $w  = $options['width'] * $rasterizer->getScaleX();
+        $h  = $options['height'] * $rasterizer->getScaleY();
 
         if ($w <= 0 || $h <= 0) {
             return array('empty' => true);
         }
 
-        $x1 = self::prepareLengthX($options['x'], $rasterizer) + $rasterizer->getOffsetX();
-        $y1 = self::prepareLengthY($options['y'], $rasterizer) + $rasterizer->getOffsetY();
+        $x1 = $options['x'] * $rasterizer->getScaleX() + $rasterizer->getOffsetX();
+        $y1 = $options['y'] * $rasterizer->getScaleY() + $rasterizer->getOffsetY();
 
         // corner radiuses may at least be (width-1)/2 pixels long.
         // anything larger than that and the circles start expanding beyond
         // the rectangle.
         // when width=0 or height=0, no radiuses should be painted - the order
         // of the ifs will take care of this.
-        $rx = empty($options['rx']) ? 0 : self::prepareLengthX($options['rx'], $rasterizer);
+        $rx = empty($options['rx']) ? 0 : $options['rx'] * $rasterizer->getScaleX();
         if ($rx > ($w - 1) / 2) {
             $rx = floor(($w - 1) / 2);
         }
         if ($rx < 0) {
             $rx = 0;
         }
-        $ry = empty($options['ry']) ? 0 : self::prepareLengthY($options['ry'], $rasterizer);
+        $ry = empty($options['ry']) ? 0 : $options['ry'] * $rasterizer->getScaleY();
         if ($ry > ($h - 1) / 2) {
             $ry = floor(($h - 1) / 2);
         }

--- a/src/Rasterization/Renderers/Renderer.php
+++ b/src/Rasterization/Renderers/Renderer.php
@@ -4,7 +4,6 @@ namespace SVG\Rasterization\Renderers;
 
 use SVG\Nodes\SVGNode;
 use SVG\Rasterization\SVGRasterizer;
-use SVG\Utilities\Units\Length;
 
 /**
  * This is the base class for all shape renderer instances.
@@ -37,36 +36,4 @@ abstract class Renderer
      * @return void
      */
     abstract public function render(SVGRasterizer $rasterizer, array $options, SVGNode $context);
-
-    /**
-     * Parses the length string in relation to the rasterizer's X dimension.
-     *
-     * @param string        $len The CSS length string.
-     * @param SVGRasterizer $ras The rasterizer for scaling the length.
-     *
-     * @return float The parsed and scaled length, in pixels.
-     */
-    protected static function prepareLengthX($len, SVGRasterizer $ras)
-    {
-        $doc   = $ras->getDocumentWidth();
-        $scale = $ras->getScaleX();
-
-        return Length::convert($len, $doc) * $scale;
-    }
-
-    /**
-     * Parses the length string in relation to the rasterizer's Y dimension.
-     *
-     * @param string        $len The CSS length string.
-     * @param SVGRasterizer $ras The rasterizer for scaling the length.
-     *
-     * @return float The parsed and scaled length, in pixels.
-     */
-    protected static function prepareLengthY($len, SVGRasterizer $ras)
-    {
-        $doc   = $ras->getDocumentWidth();
-        $scale = $ras->getScaleY();
-
-        return Length::convert($len, $doc) * $scale;
-    }
 }

--- a/src/Rasterization/Renderers/TextRenderer.php
+++ b/src/Rasterization/Renderers/TextRenderer.php
@@ -22,7 +22,7 @@ class TextRenderer extends MultiPassRenderer
      */
     protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
     {
-        $size = self::prepareLengthY($options['size'], $rasterizer);
+        $size = $options['size'] * $rasterizer->getScaleY();
 
         // text-anchor
         $anchorOffset = 0;
@@ -31,8 +31,8 @@ class TextRenderer extends MultiPassRenderer
             $anchorOffset = $options['anchor'] === 'middle' ? ($width / 2) : $width;
         }
 
-        $x = self::prepareLengthX($options['x'], $rasterizer) + $rasterizer->getOffsetX();
-        $y = self::prepareLengthY($options['y'], $rasterizer) + $rasterizer->getOffsetY();
+        $x = $options['x'] * $rasterizer->getScaleX() + $rasterizer->getOffsetX();
+        $y = $options['y'] * $rasterizer->getScaleY() + $rasterizer->getOffsetY();
 
         return array(
             'x'         => $x - $anchorOffset,

--- a/tests/Nodes/Embedded/SVGImageTest.php
+++ b/tests/Nodes/Embedded/SVGImageTest.php
@@ -192,10 +192,10 @@ class SVGImageTest extends \PHPUnit\Framework\TestCase
             $this->identicalTo('image'),
             $this->identicalTo(array(
                 'href' => 'test-href',
-                'x' => '10',
-                'y' => '10',
-                'width' => '100',
-                'height' => '100',
+                'x' => 10.0,
+                'y' => 10.0,
+                'width' => 100.0,
+                'height' => 100.0,
             )),
             $this->identicalTo($obj)
         );

--- a/tests/Nodes/Shapes/SVGCircleTest.php
+++ b/tests/Nodes/Shapes/SVGCircleTest.php
@@ -126,10 +126,10 @@ class SVGCircleTest extends \PHPUnit\Framework\TestCase
         $rast->expects($this->once())->method('render')->with(
             $this->identicalTo('ellipse'),
             $this->identicalTo(array(
-                'cx' => '37',
-                'cy' => '42',
-                'rx' => '100',
-                'ry' => '100',
+                'cx' => 37.0,
+                'cy' => 42.0,
+                'rx' => 100.0,
+                'ry' => 100.0,
             )),
             $this->identicalTo($obj)
         );

--- a/tests/Nodes/Shapes/SVGEllipseTest.php
+++ b/tests/Nodes/Shapes/SVGEllipseTest.php
@@ -154,10 +154,10 @@ class SVGEllipseTest extends \PHPUnit\Framework\TestCase
         $rast->expects($this->once())->method('render')->with(
             $this->identicalTo('ellipse'),
             $this->identicalTo(array(
-                'cx' => '37',
-                'cy' => '42',
-                'rx' => '100',
-                'ry' => '200',
+                'cx' => 37.0,
+                'cy' => 42.0,
+                'rx' => 100.0,
+                'ry' => 200.0,
             )),
             $this->identicalTo($obj)
         );

--- a/tests/Nodes/Shapes/SVGLineTest.php
+++ b/tests/Nodes/Shapes/SVGLineTest.php
@@ -154,10 +154,10 @@ class SVGLineTest extends \PHPUnit\Framework\TestCase
         $rast->expects($this->once())->method('render')->with(
             $this->identicalTo('line'),
             $this->identicalTo(array(
-                'x1' => '11',
-                'y1' => '12',
-                'x2' => '13',
-                'y2' => '14',
+                'x1' => 11.0,
+                'y1' => 12.0,
+                'x2' => 13.0,
+                'y2' => 14.0,
             )),
             $this->identicalTo($obj)
         );

--- a/tests/Nodes/Shapes/SVGRectTest.php
+++ b/tests/Nodes/Shapes/SVGRectTest.php
@@ -210,12 +210,12 @@ class SVGRectTest extends \PHPUnit\Framework\TestCase
         $rast->expects($this->once())->method('render')->with(
             $this->identicalTo('rect'),
             $this->identicalTo(array(
-                'x' => '37',
-                'y' => '42',
-                'width' => '100',
-                'height' => '200',
-                'rx' => '15',
-                'ry' => '25',
+                'x' => 37.0,
+                'y' => 42.0,
+                'width' => 100.0,
+                'height' => 200.0,
+                'rx' => 15.0,
+                'ry' => 25.0,
             )),
             $this->identicalTo($obj)
         );

--- a/tests/Rasterization/Renderers/RectRendererTest.php
+++ b/tests/Rasterization/Renderers/RectRendererTest.php
@@ -25,8 +25,8 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('40px', '40px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '4px', 'y' => '8px',
-            'width' => '20px', 'height' => '16px',
+            'x' => 4, 'y' => 8,
+            'width' => 20, 'height' => 16,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -44,8 +44,8 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('20px', '20px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '2px', 'y' => '4px',
-            'width' => '10px', 'height' => '8px',
+            'x' => 2, 'y' => 4,
+            'width' => 10, 'height' => 8,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -63,8 +63,8 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('20px', '20px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '2px', 'y' => '4px',
-            'width' => '10px', 'height' => '8px',
+            'x' => 2, 'y' => 4,
+            'width' => 10, 'height' => 8,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -81,8 +81,8 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('20px', '20px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '2px', 'y' => '4px',
-            'width' => '10px', 'height' => '8px',
+            'x' => 2, 'y' => 4,
+            'width' => 10, 'height' => 8,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -99,8 +99,8 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('20px', '20px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '2px', 'y' => '4px',
-            'width' => '10px', 'height' => '8px',
+            'x' => 2, 'y' => 4,
+            'width' => 10, 'height' => 8,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -118,8 +118,8 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('40px', '40px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '4px', 'y' => '8px',
-            'width' => '20px', 'height' => '16px',
+            'x' => 4, 'y' => 8,
+            'width' => 20, 'height' => 16,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -137,9 +137,9 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('40px', '40px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '4px', 'y' => '8px',
-            'width' => '20px', 'height' => '16px',
-            'rx' => '10%', 'ry' => '10%',
+            'x' => 4, 'y' => 8,
+            'width' => 20, 'height' => 16,
+            'rx' => 4, 'ry' => 4,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -156,9 +156,9 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('40px', '40px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '4px', 'y' => '8px',
-            'width' => '20px', 'height' => '16px',
-            'rx' => '10%', 'ry' => '10%',
+            'x' => 4, 'y' => 8,
+            'width' => 20, 'height' => 16,
+            'rx' => 4, 'ry' => 4,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -176,9 +176,9 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('40px', '40px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '4px', 'y' => '8px',
-            'width' => '0', 'height' => '16px',
-            'rx' => '10%', 'ry' => '10%',
+            'x' => 4, 'y' => 8,
+            'width' => 0, 'height' => 16,
+            'rx' => 4, 'ry' => 4,
         ), $context);
         $img = $rasterizer->finish();
 
@@ -196,9 +196,9 @@ class RectRendererTest extends \PHPUnit\Framework\TestCase
 
         $rasterizer = new SVGRasterizer('40px', '40px', null, 40, 40);
         $obj->render($rasterizer, array(
-            'x' => '4px', 'y' => '8px',
-            'width' => '20px', 'height' => '0',
-            'rx' => '10%', 'ry' => '10%',
+            'x' => 4, 'y' => 8,
+            'width' => 20, 'height' => 0,
+            'rx' => 4, 'ry' => 4,
         ), $context);
         $img = $rasterizer->finish();
 


### PR DESCRIPTION
This allows for a better separation of concerns between nodes and
renderer implementations. Now, the renderers always get resolved pixel
values for all their position and length inputs. This means they only
have to care about transforming the coordinates into the render target
coordinate space by scaling and offsetting, and not have to care about
resolving strings with units against viewport lengths.

Regarding the last point: The spec clearly states that lengths for
properties such as 'ry', 'height' etc. must be resolved against the
document height instead of width. This is now fixed. Others, such as
'stroke-width' or 'r' need to be resolved against the diagonal.
This also makes this change somewhat mandatory: The 'ellipse' renderer
cannot know whether to resolve both 'rx' and 'ry' against the diagonal
(for rendering a circle) or resolve them against width and height
separately (for rendering an ellipse).