### PR TITLE
feat: Add resize() method to Transform for measuring width/height scale

### DIFF
--- a/src/Rasterization/Transform/Transform.php
+++ b/src/Rasterization/Transform/Transform.php
@@ -83,6 +83,20 @@ class Transform
         $destination[] = $y;
     }
 
+    /**
+     * This computes the side lengths that a rectangle with the given size would end up having,
+     * after applying the transform. Note that this doesn't measure the bounding box but the actual width and height.
+     *
+     * @param float $width  The original width.
+     * @param float $height The original height.
+     * @return void
+     */
+    public function resize(&$width, &$height)
+    {
+        $width  *= hypot($this->matrix[0], $this->matrix[1]);
+        $height *= hypot($this->matrix[2], $this->matrix[3]);
+    }
+
     // mutation functions
 
     /**

--- a/tests/Rasterization/Transform/TransformTest.php
+++ b/tests/Rasterization/Transform/TransformTest.php
@@ -5,7 +5,7 @@ namespace SVG;
 use SVG\Rasterization\Transform\Transform;
 
 /**
- * @covers \SVG\Rasterization\Transform\Transform
+ * @coversDefaultClass \SVG\Rasterization\Transform\Transform
  *
  * @SuppressWarnings(PHPMD)
  */


### PR DESCRIPTION
This method is currently unused, but will be useful later when
implementing transform support for shapes.