### PR TITLE
refactor: Use Transform class for viewport scale+offset during render

### DIFF
--- a/src/Rasterization/Renderers/EllipseRenderer.php
+++ b/src/Rasterization/Renderers/EllipseRenderer.php
@@ -2,7 +2,7 @@
 
 namespace SVG\Rasterization\Renderers;
 
-use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\Transform;
 
 /**
  * This renderer can draw ellipses (and circles).
@@ -18,13 +18,21 @@ class EllipseRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
+    protected function prepareRenderParams(array $options, Transform $transform)
     {
+        $cx = $options['cx'];
+        $cy = $options['cy'];
+        $transform->map($cx, $cy);
+
+        $width = $options['rx'] * 2;
+        $height = $options['ry'] * 2;
+        $transform->resize($width, $height);
+
         return array(
-            'cx'        => $options['cx'] * $rasterizer->getScaleX() + $rasterizer->getOffsetX(),
-            'cy'        => $options['cy'] * $rasterizer->getScaleY() + $rasterizer->getOffsetY(),
-            'width'     => $options['rx'] * $rasterizer->getScaleX() * 2,
-            'height'    => $options['ry'] * $rasterizer->getScaleY() * 2,
+            'cx'        => $cx,
+            'cy'        => $cy,
+            'width'     => $width,
+            'height'    => $height,
         );
     }
 

--- a/src/Rasterization/Renderers/ImageRenderer.php
+++ b/src/Rasterization/Renderers/ImageRenderer.php
@@ -23,10 +23,15 @@ class ImageRenderer extends Renderer
      */
     public function render(SVGRasterizer $rasterizer, array $options, SVGNode $context)
     {
-        $x      = $options['x'] * $rasterizer->getScaleX() + $rasterizer->getOffsetX();
-        $y      = $options['y'] * $rasterizer->getScaleY() + $rasterizer->getOffsetY();
-        $width  = $options['width'] * $rasterizer->getScaleY();
-        $height = $options['height'] * $rasterizer->getScaleX();
+        $transform = $rasterizer->makeTransform();
+
+        $x      = $options['x'];
+        $y      = $options['y'];
+        $transform->map($x, $y);
+
+        $width  = $options['width'];
+        $height = $options['height'];
+        $transform->resize($width, $height);
 
         $image = $rasterizer->getImage();
 

--- a/src/Rasterization/Renderers/LineRenderer.php
+++ b/src/Rasterization/Renderers/LineRenderer.php
@@ -2,7 +2,7 @@
 
 namespace SVG\Rasterization\Renderers;
 
-use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\Transform;
 
 /**
  * This renderer can draw straight lines. Filling is not supported.
@@ -18,16 +18,21 @@ class LineRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
+    protected function prepareRenderParams(array $options, Transform $transform)
     {
-        $offsetX = $rasterizer->getOffsetX();
-        $offsetY = $rasterizer->getOffsetY();
+        $x1 = $options['x1'];
+        $y1 = $options['y1'];
+        $transform->map($x1, $y1);
+
+        $x2 = $options['x2'];
+        $y2 = $options['y2'];
+        $transform->map($x2, $y2);
 
         return array(
-            'x1' => $options['x1'] * $rasterizer->getScaleX() + $offsetX,
-            'y1' => $options['y1'] * $rasterizer->getScaleY() + $offsetY,
-            'x2' => $options['x2'] * $rasterizer->getScaleX() + $offsetX,
-            'y2' => $options['y2'] * $rasterizer->getScaleY() + $offsetY,
+            'x1' => $x1,
+            'y1' => $y1,
+            'x2' => $x2,
+            'y2' => $y2,
         );
     }
 

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -4,6 +4,7 @@ namespace SVG\Rasterization\Renderers;
 
 use SVG\Nodes\SVGNode;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\Transform;
 use SVG\Utilities\Colors\Color;
 use SVG\Utilities\Units\Length;
 
@@ -19,7 +20,9 @@ abstract class MultiPassRenderer extends Renderer
      */
     public function render(SVGRasterizer $rasterizer, array $options, SVGNode $context)
     {
-        $params = $this->prepareRenderParams($rasterizer, $options);
+        $transform = $rasterizer->makeTransform();
+
+        $params = $this->prepareRenderParams($options, $transform);
 
         $paintOrder = self::getPaintOrder($context);
         foreach ($paintOrder as $paint) {
@@ -76,12 +79,12 @@ abstract class MultiPassRenderer extends Renderer
      * method rather than dealing with it in the render methods. This shall
      * encourage single passes over the input data (for performance reasons).
      *
-     * @param SVGRasterizer $rasterizer The rasterizer used in this render.
-     * @param mixed[]       $options    The associative array of raw options.
+     * @param array     $options   The associative array of raw options.
+     * @param Transform $transform The coordinate transform to apply, to go from user coordinate to output coordinates.
      *
-     * @return mixed[] The new associative array of computed render parameters.
+     * @return array The new associative array of computed render parameters.
      */
-    abstract protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options);
+    abstract protected function prepareRenderParams(array $options, Transform $transform);
 
     /**
      * Renders the shape's filled version in the given color, using the params

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -2,7 +2,7 @@
 
 namespace SVG\Rasterization\Renderers;
 
-use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\Transform;
 
 /**
  * This renderer can draw pre-approximated paths, which are sets of line segments. These segments can potentially
@@ -18,20 +18,13 @@ class PathRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
+    protected function prepareRenderParams(array $options, Transform $transform)
     {
-        $scaleX = $rasterizer->getScaleX();
-        $scaleY = $rasterizer->getScaleY();
-
-        $offsetX = $rasterizer->getOffsetX();
-        $offsetY = $rasterizer->getOffsetY();
-
         $segments = array();
         foreach ($options['segments'] as $segment) {
             $points = array();
             foreach ($segment as $point) {
-                $points[] = $point[0] * $scaleX + $offsetX;
-                $points[] = $point[1] * $scaleY + $offsetY;
+                $transform->mapInto($point[0], $point[1], $points);
             }
             $segments[] = $points;
         }

--- a/src/Rasterization/Renderers/PolygonRenderer.php
+++ b/src/Rasterization/Renderers/PolygonRenderer.php
@@ -2,7 +2,7 @@
 
 namespace SVG\Rasterization\Renderers;
 
-use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\Transform;
 
 /**
  * This renderer can draw polygons and polylines.
@@ -17,18 +17,11 @@ class PolygonRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
+    protected function prepareRenderParams(array $options, Transform $transform)
     {
-        $scaleX = $rasterizer->getScaleX();
-        $scaleY = $rasterizer->getScaleY();
-
-        $offsetX = $rasterizer->getOffsetX();
-        $offsetY = $rasterizer->getOffsetY();
-
         $points = array();
         foreach ($options['points'] as $point) {
-            $points[] = $point[0] * $scaleX + $offsetX;
-            $points[] = $point[1] * $scaleY + $offsetY;
+            $transform->mapInto($point[0], $point[1], $points);
         }
 
         return array(

--- a/src/Rasterization/Renderers/RectRenderer.php
+++ b/src/Rasterization/Renderers/RectRenderer.php
@@ -2,7 +2,7 @@
 
 namespace SVG\Rasterization\Renderers;
 
-use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\Transform;
 
 /**
  * This renderer can draw rectangles.
@@ -20,31 +20,31 @@ class RectRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
+    protected function prepareRenderParams(array $options, Transform $transform)
     {
-        $w  = $options['width'] * $rasterizer->getScaleX();
-        $h  = $options['height'] * $rasterizer->getScaleY();
+        $w = $options['width'];
+        $h = $options['height'];
+        $transform->resize($w, $h);
 
         if ($w <= 0 || $h <= 0) {
             return array('empty' => true);
         }
 
-        $x1 = $options['x'] * $rasterizer->getScaleX() + $rasterizer->getOffsetX();
-        $y1 = $options['y'] * $rasterizer->getScaleY() + $rasterizer->getOffsetY();
+        $x1 = $options['x'];
+        $y1 = $options['y'];
+        $transform->map($x1, $y1);
 
-        // corner radiuses may at least be (width-1)/2 pixels long.
-        // anything larger than that and the circles start expanding beyond
-        // the rectangle.
-        // when width=0 or height=0, no radiuses should be painted - the order
-        // of the ifs will take care of this.
-        $rx = empty($options['rx']) ? 0 : $options['rx'] * $rasterizer->getScaleX();
+        // Corner radii may at most be (width-1)/2 pixels long.
+        // Anything larger than that and the circles start expanding beyond the rectangle.
+        $rx = empty($options['rx']) ? 0 : $options['rx'];
+        $ry = empty($options['ry']) ? 0 : $options['ry'];
+        $transform->resize($rx, $ry);
         if ($rx > ($w - 1) / 2) {
             $rx = floor(($w - 1) / 2);
         }
         if ($rx < 0) {
             $rx = 0;
         }
-        $ry = empty($options['ry']) ? 0 : $options['ry'] * $rasterizer->getScaleY();
         if ($ry > ($h - 1) / 2) {
             $ry = floor(($h - 1) / 2);
         }
@@ -72,7 +72,7 @@ class RectRenderer extends MultiPassRenderer
             return;
         }
 
-        if ($params['rx'] !== 0 || $params['ry'] !== 0) {
+        if ($params['rx'] != 0 || $params['ry'] != 0) {
             $this->renderFillRounded($image, $params, $color);
             return;
         }
@@ -138,7 +138,7 @@ class RectRenderer extends MultiPassRenderer
 
         imagesetthickness($image, round($strokeWidth));
 
-        if ($params['rx'] !== 0 || $params['ry'] !== 0) {
+        if ($params['rx'] != 0 || $params['ry'] != 0) {
             $this->renderStrokeRounded($image, $params, $color, $strokeWidth);
             return;
         }

--- a/src/Rasterization/Renderers/TextRenderer.php
+++ b/src/Rasterization/Renderers/TextRenderer.php
@@ -2,7 +2,7 @@
 
 namespace SVG\Rasterization\Renderers;
 
-use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\Transform;
 
 /**
  * This renderer can draw basic text.
@@ -20,9 +20,13 @@ class TextRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(SVGRasterizer $rasterizer, array $options)
+    protected function prepareRenderParams(array $options, Transform $transform)
     {
-        $size = $options['size'] * $rasterizer->getScaleY();
+        // this assumes there is no rotation or skew, but that's fine, we can't deal with that anyway
+        $size1 = $options['size'];
+        $size2 = $size1;
+        $transform->resize($size1, $size2);
+        $size = min($size1, $size2);
 
         // text-anchor
         $anchorOffset = 0;
@@ -31,8 +35,9 @@ class TextRenderer extends MultiPassRenderer
             $anchorOffset = $options['anchor'] === 'middle' ? ($width / 2) : $width;
         }
 
-        $x = $options['x'] * $rasterizer->getScaleX() + $rasterizer->getOffsetX();
-        $y = $options['y'] * $rasterizer->getScaleY() + $rasterizer->getOffsetY();
+        $x = $options['x'];
+        $y = $options['y'];
+        $transform->map($x, $y);
 
         return array(
             'x'         => $x - $anchorOffset,

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -254,22 +254,6 @@ class SVGRasterizer
     }
 
     /**
-     * @return float The factor by which the output is scaled on the x axis.
-     */
-    public function getScaleX()
-    {
-        return $this->scaleX;
-    }
-
-    /**
-     * @return float The factor by which the output is scaled on the y axis.
-     */
-    public function getScaleY()
-    {
-        return $this->scaleY;
-    }
-
-    /**
      * Determine the normalized diagonal scaling factor. This is the factor that should be used when scaling percentages
      * for properties that are not strictly horizontal or strictly vertical, such as stroke-width.
      *
@@ -278,24 +262,6 @@ class SVGRasterizer
     public function getDiagonalScale()
     {
         return hypot($this->scaleX, $this->scaleY) / M_SQRT2;
-    }
-
-    /**
-     * @return float The amount by which renderers must offset their drawings
-     *               on the x-axis (not to be scaled).
-     */
-    public function getOffsetX()
-    {
-        return $this->offsetX;
-    }
-
-    /**
-     * @return float The amount by which renderers must offset their drawings
-     *               on the y-axis (not to be scaled).
-     */
-    public function getOffsetY()
-    {
-        return $this->offsetY;
     }
 
     /**

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -4,6 +4,7 @@ namespace SVG\Rasterization;
 
 use InvalidArgumentException;
 use SVG\Nodes\SVGNode;
+use SVG\Rasterization\Transform\Transform;
 use SVG\Utilities\Units\Length;
 use SVG\Utilities\Colors\Color;
 
@@ -303,6 +304,19 @@ class SVGRasterizer
     public function getViewBox()
     {
         return $this->viewBox;
+    }
+
+    /**
+     * Obtain a Transform object from userspace coordinates into output image coordinates.
+     *
+     * @return Transform The created transform.
+     */
+    public function makeTransform()
+    {
+        $transform = Transform::identity();
+        $transform->translate($this->offsetX, $this->offsetY);
+        $transform->scale($this->scaleX, $this->scaleY);
+        return $transform;
     }
 
     /**

--- a/tests/Rasterization/Renderers/MultiPassRendererTest.php
+++ b/tests/Rasterization/Renderers/MultiPassRendererTest.php
@@ -41,8 +41,8 @@ class MultiPassRendererTest extends \PHPUnit\Framework\TestCase
         // should call prepareRenderParams with correct arguments
         $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
         $obj->expects($this->once())->method('prepareRenderParams')->with(
-            $this->identicalTo($rast),
-            $this->identicalTo($options)
+            $this->identicalTo($options),
+            $this->isInstanceOf('\SVG\Rasterization\Transform\Transform')
         )->willReturn($params);
         $obj->render($rast, $options, $node);
 

--- a/tests/Rasterization/SVGRasterizerTest.php
+++ b/tests/Rasterization/SVGRasterizerTest.php
@@ -102,38 +102,6 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers ::getScaleX
-     */
-    public function testGetScaleX()
-    {
-        // should use viewBox dimension when available
-        $obj = new SVGRasterizer(10, 20, array(37, 42, 25, 100), 100, 200);
-        $this->assertEquals(4, $obj->getScaleX());
-        imagedestroy($obj->getImage());
-
-        // should use document dimension when viewBox unavailable
-        $obj = new SVGRasterizer(10, 20, array(), 100, 200);
-        $this->assertEquals(10, $obj->getScaleX());
-        imagedestroy($obj->getImage());
-    }
-
-    /**
-     * @covers ::getScaleY
-     */
-    public function testGetScaleY()
-    {
-        // should use viewBox dimension when available
-        $obj = new SVGRasterizer(10, 20, array(37, 42, 25, 100), 100, 200);
-        $this->assertEquals(2, $obj->getScaleY());
-        imagedestroy($obj->getImage());
-
-        // should use document dimension when viewBox unavailable
-        $obj = new SVGRasterizer(10, 20, array(), 100, 200);
-        $this->assertEquals(10, $obj->getScaleY());
-        imagedestroy($obj->getImage());
-    }
-
-    /**
      * @covers ::getDiagonalScale
      */
     public function testGetDiagonalScale()
@@ -149,37 +117,6 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
         imagedestroy($obj->getImage());
     }
 
-    /**
-     * @covers ::getOffsetX
-     */
-    public function testGetOffsetX()
-    {
-        // should return scaled viewBox offset when available
-        $obj = new SVGRasterizer(10, 20, array(37, 42, 25, 100), 100, 200);
-        $this->assertEquals(-37 * $obj->getScaleX(), $obj->getOffsetX());
-        imagedestroy($obj->getImage());
-
-        // should return 0 when viewBox unavailable
-        $obj = new SVGRasterizer(10, 20, array(), 100, 200);
-        $this->assertEquals(0, $obj->getOffsetX());
-        imagedestroy($obj->getImage());
-    }
-
-    /**
-     * @covers ::getOffsetY
-     */
-    public function testGetOffsetY()
-    {
-        // should return scaled viewBox offset when available
-        $obj = new SVGRasterizer(10, 20, array(37, 42, 25, 100), 100, 200);
-        $this->assertEquals(-42 * $obj->getScaleY(), $obj->getOffsetY());
-        imagedestroy($obj->getImage());
-
-        // should return 0 when viewBox unavailable
-        $obj = new SVGRasterizer(10, 20, array(), 100, 200);
-        $this->assertEquals(0, $obj->getOffsetY());
-        imagedestroy($obj->getImage());
-    }
 
     /**
      * @covers ::getViewbox

--- a/tests/Rasterization/SVGRasterizerTest.php
+++ b/tests/Rasterization/SVGRasterizerTest.php
@@ -158,6 +158,30 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::makeTransform
+     */
+    public function testMakeTransform()
+    {
+        // should use viewBox dimension when available
+        $obj = new SVGRasterizer(10, 20, array(37, 42, 25, 80), 100, 160);
+        $transform = $obj->makeTransform();
+        $x = 100;
+        $y = 100;
+        $transform->map($x, $y);
+        $this->assertEquals(array(4 * 100 + 4 * -37, 2 * 100 + 2 * -42), array($x, $y));
+        imagedestroy($obj->getImage());
+
+        // should use document dimension when viewBox unavailable
+        $obj = new SVGRasterizer(10, 20, array(), 100, 160);
+        $transform = $obj->makeTransform();
+        $x = 100;
+        $y = 100;
+        $transform->map($x, $y);
+        $this->assertEquals(array(1000, 800), array($x, $y));
+        imagedestroy($obj->getImage());
+    }
+
+    /**
      * @covers ::render
      */
     public function testRenderWithNoSuchRenderId()


### PR DESCRIPTION
SVGRasterizer::makeTransform() is added to obtain a Transform object
representing the mapping of userspace coordinates into image
coordinates, just like it was previously done manually by scaling and
then translating every coordinate inside the renderers. These
computations can now be replaced by simple calls to Transform::map and
related methods.

By doing this, the MultiPassRenderer::prepareRenderParams() method does
not even need access to the SVGRasterizer anymore.

Note that handling of the `transform` attribute or style is not part of
this change.