### PR TITLE
feat: Implement TransformParser for converting strings to Transform

### DIFF
--- a/src/Rasterization/Path/PathApproximator.php
+++ b/src/Rasterization/Path/PathApproximator.php
@@ -164,6 +164,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function moveTo($id, $args, PolygonBuilder $builder)
     {
@@ -184,6 +185,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function lineTo($id, $args, PolygonBuilder $builder)
     {
@@ -204,6 +206,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function lineToHorizontal($id, $args, PolygonBuilder $builder)
     {
@@ -224,6 +227,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function lineToVertical($id, $args, PolygonBuilder $builder)
     {
@@ -244,6 +248,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function curveToCubic($id, $args, PolygonBuilder $builder)
     {
@@ -279,6 +284,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function curveToCubicSmooth($id, $args, PolygonBuilder $builder)
     {
@@ -317,6 +323,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function curveToQuadratic($id, $args, PolygonBuilder $builder)
     {
@@ -348,6 +355,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function curveToQuadraticSmooth($id, $args, PolygonBuilder $builder)
     {
@@ -382,6 +390,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function arcTo($id, $args, PolygonBuilder $builder)
     {
@@ -415,6 +424,7 @@ class PathApproximator
      * @return void
      *
      * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
      */
     private function closePath($id, $args, PolygonBuilder $builder)
     {

--- a/src/Rasterization/Transform/TransformParser.php
+++ b/src/Rasterization/Transform/TransformParser.php
@@ -21,8 +21,9 @@ final class TransformParser
 
         // https://www.w3.org/TR/css-transforms-1/#svg-syntax
 
-        $matches  = array();
-        preg_match_all('/(translate|scale|rotate|skewX|skewY|matrix)\s*\(\s*([^)]+)\s*\)/', $input, $matches, PREG_SET_ORDER);
+        $matches = array();
+        preg_match_all('/(translate|scale|rotate|skewX|skewY|matrix)\s*\(\s*([^)]+)\s*\)/', $input, $matches,
+            PREG_SET_ORDER);
 
         foreach ($matches as $match) {
             $operation = $match[1];

--- a/src/Rasterization/Transform/TransformParser.php
+++ b/src/Rasterization/Transform/TransformParser.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SVG\Rasterization\Transform;
+
+final class TransformParser
+{
+    /**
+     * Convert a 'transform' attribute value into a Transform object by starting with the identity transform and
+     * applying each of the operations specified in the input string.
+     * Alternatively, if a Transform object already exists to which further operations should be added, it can be
+     * passed as an argument. In that case, no new Transform object will be allocated, and the given one will be used
+     * as the starting point instead.
+     *
+     * @param string         $input   The string to parse.
+     * @param Transform|null $applyTo The optional starting Transform. If not provided, the identity will be used.
+     * @return Transform Either the mutated argument transform, or the newly computed transform.
+     */
+    public static function parseTransformString($input, Transform $applyTo = null)
+    {
+        $transform = isset($applyTo) ? $applyTo : Transform::identity();
+
+        // https://www.w3.org/TR/css-transforms-1/#svg-syntax
+
+        $matches  = array();
+        preg_match_all('/(translate|scale|rotate|skewX|skewY|matrix)\s*\(\s*([^)]+)\s*\)/', $input, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $operation = $match[1];
+            $arguments = self::splitArguments($match[2]);
+
+            self::$operation($transform, $arguments);
+        }
+
+        return $transform;
+    }
+
+    private static function splitArguments($argumentString)
+    {
+        $args = array();
+        if ($argumentString !== '') {
+            preg_match_all('/[+-]?(\d*\.\d+|\d+)(e[+-]?\d+)?/', $argumentString, $args);
+            $args = $args[0];
+        }
+
+        return $args;
+    }
+
+    // the following functions are invoked dynamically
+
+    /**
+     * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
+     */
+    private static function translate(Transform $transform, array $arguments)
+    {
+        if (count($arguments) === 2) {
+            $transform->translate((float) $arguments[0], (float) $arguments[1]);
+        }
+    }
+
+    /**
+     * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
+     */
+    private static function scale(Transform $transform, array $arguments)
+    {
+        if (count($arguments) === 2) {
+            $transform->scale((float) $arguments[0], (float) $arguments[1]);
+        }
+    }
+
+    /**
+     * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
+     */
+    private static function rotate(Transform $transform, array $arguments)
+    {
+        if (count($arguments) === 1) {
+            $transform->rotate(deg2rad((float) $arguments[0]));
+        }
+    }
+
+    /**
+     * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
+     */
+    private static function skewX(Transform $transform, array $arguments)
+    {
+        if (count($arguments) === 1) {
+            $transform->skewX(deg2rad((float) $arguments[0]));
+        }
+    }
+
+    /**
+     * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
+     */
+    private static function skewY(Transform $transform, array $arguments)
+    {
+        if (count($arguments) === 1) {
+            $transform->skewY(deg2rad((float) $arguments[0]));
+        }
+    }
+
+    /**
+     * @SuppressWarnings("unused")
+     * @noinspection PhpUnusedPrivateMethodInspection
+     */
+    private static function matrix(Transform $transform, array $arguments)
+    {
+        if (count($arguments) === 6) {
+            $transform->multiply(new Transform(array_map('floatval', $arguments)));
+        }
+    }
+}

--- a/src/Rasterization/Transform/TransformParser.php
+++ b/src/Rasterization/Transform/TransformParser.php
@@ -22,8 +22,12 @@ final class TransformParser
         // https://www.w3.org/TR/css-transforms-1/#svg-syntax
 
         $matches = array();
-        preg_match_all('/(translate|scale|rotate|skewX|skewY|matrix)\s*\(\s*([^)]+)\s*\)/', $input, $matches,
-            PREG_SET_ORDER);
+        preg_match_all(
+            '/(translate|scale|rotate|skewX|skewY|matrix)\s*\(\s*([^)]+)\s*\)/',
+            $input,
+            $matches,
+            PREG_SET_ORDER
+        );
 
         foreach ($matches as $match) {
             $operation = $match[1];

--- a/tests/Rasterization/Transform/TransformParserTest.php
+++ b/tests/Rasterization/Transform/TransformParserTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SVG;
+
+use SVG\Rasterization\Transform\Transform;
+use SVG\Rasterization\Transform\TransformParser;
+
+/**
+ * @coversDefaultClass \SVG\Rasterization\Transform\TransformParser
+ *
+ * @SuppressWarnings(PHPMD)
+ */
+class TransformParserTest extends \PHPUnit\Framework\TestCase
+{
+    private function assertMap(Transform $t, array $expected, array $source)
+    {
+        $t->map($source[0], $source[1]);
+        $this->assertEquals($expected, $source);
+    }
+
+    public function testParseTransformString()
+    {
+        $transform = TransformParser::parseTransformString('translate(10,20) scale(3,7) rotate(90)');
+        $this->assertMap($transform, array(-290, 720), array(100, 100));
+
+        // should not care about whitespace
+        $transform = TransformParser::parseTransformString("  translate  (  10  ,  20  ) \nscale(3, 7) rotate(90)  ");
+        $this->assertMap($transform, array(-290, 720), array(100, 100));
+
+        // should not fail for missing arguments
+        $this->assertNotNull(TransformParser::parseTransformString('translate(10)'));
+    }
+}

--- a/tests/Rasterization/Transform/TransformTest.php
+++ b/tests/Rasterization/Transform/TransformTest.php
@@ -13,18 +13,14 @@ class TransformTest extends \PHPUnit\Framework\TestCase
 {
     private function assertMap(Transform $t, array $expected, array $source)
     {
-        $x = $source[0];
-        $y = $source[1];
-        $t->map($x, $y);
-        $this->assertEquals($expected, array($x, $y));
+        $t->map($source[0], $source[1]);
+        $this->assertEquals($expected, $source);
     }
 
     private function assertResized(Transform $t, array $expected, array $source)
     {
-        $width = $source[0];
-        $height = $source[1];
-        $t->resize($width, $height);
-        $this->assertEquals($expected, array($width, $height));
+        $t->resize($source[0], $source[1]);
+        $this->assertEquals($expected, $source);
     }
 
     public function testIdentity()


### PR DESCRIPTION
This class provides a static method parseTransformString() for parsing
strings such as 'translate(10,20) rotate(45)' into Transform objects.
This new method will be used later, when implementing support for node
transforms in rendering. That feature is not part of this patch though.