### PR TITLE
feat: Add SVGRasterizer::pushTransform() and ::popTransform()

### DIFF
--- a/src/Nodes/Embedded/SVGImage.php
+++ b/src/Nodes/Embedded/SVGImage.php
@@ -5,6 +5,7 @@ namespace SVG\Nodes\Embedded;
 use RuntimeException;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 use SVG\Utilities\Units\Length;
 
 /**
@@ -205,6 +206,8 @@ class SVGImage extends SVGNodeContainer
             return;
         }
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         $rasterizer->render('image', array(
             'href'      => $this->getHref(),
             'x'         => Length::convert($this->getX(), $rasterizer->getDocumentWidth()),
@@ -212,5 +215,7 @@ class SVGImage extends SVGNodeContainer
             'width'     => Length::convert($this->getWidth(), $rasterizer->getDocumentWidth()),
             'height'    => Length::convert($this->getHeight(), $rasterizer->getDocumentHeight()),
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/SVGNodeContainer.php
+++ b/src/Nodes/SVGNodeContainer.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes;
 
 use SVG\Nodes\Structures\SVGStyle;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 use SVG\Utilities\SVGStyleParser;
 
 /**
@@ -166,9 +167,13 @@ abstract class SVGNodeContainer extends SVGNode
 
         // 'visibility' can be overridden -> only applied in shape nodes.
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         foreach ($this->children as $child) {
             $child->rasterize($rasterizer);
         }
+
+        $rasterizer->popTransform();
     }
 
     /**

--- a/src/Nodes/Shapes/SVGCircle.php
+++ b/src/Nodes/Shapes/SVGCircle.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 use SVG\Utilities\Units\Length;
 
 /**
@@ -102,6 +103,8 @@ class SVGCircle extends SVGNodeContainer
             return;
         }
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         // https://svgwg.org/svg2-draft/geometry.html#R
         // Percentages: refer to the normalized diagonal of the current SVG viewport
         $r = Length::convert($this->getRadius(), $rasterizer->getNormalizedDiagonal());
@@ -112,5 +115,7 @@ class SVGCircle extends SVGNodeContainer
             'rx'    => $r,
             'ry'    => $r,
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/Shapes/SVGEllipse.php
+++ b/src/Nodes/Shapes/SVGEllipse.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 use SVG\Utilities\Units\Length;
 
 /**
@@ -124,11 +125,15 @@ class SVGEllipse extends SVGNodeContainer
             return;
         }
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         $rasterizer->render('ellipse', array(
             'cx'    => Length::convert($this->getCenterX(), $rasterizer->getDocumentWidth()),
             'cy'    => Length::convert($this->getCenterY(), $rasterizer->getDocumentHeight()),
             'rx'    => Length::convert($this->getRadiusX(), $rasterizer->getDocumentWidth()),
             'ry'    => Length::convert($this->getRadiusY(), $rasterizer->getDocumentHeight()),
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/Shapes/SVGLine.php
+++ b/src/Nodes/Shapes/SVGLine.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 use SVG\Utilities\Units\Length;
 
 /**
@@ -124,11 +125,15 @@ class SVGLine extends SVGNodeContainer
             return;
         }
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         $rasterizer->render('line', array(
             'x1'    => Length::convert($this->getX1(), $rasterizer->getDocumentWidth()),
             'y1'    => Length::convert($this->getY1(), $rasterizer->getDocumentHeight()),
             'x2'    => Length::convert($this->getX2(), $rasterizer->getDocumentWidth()),
             'y2'    => Length::convert($this->getY2(), $rasterizer->getDocumentHeight()),
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 
 /**
  * Represents the SVG tag 'path'.
@@ -64,9 +65,13 @@ class SVGPath extends SVGNodeContainer
         $commands = $rasterizer->getPathParser()->parse($d);
         $subpaths = $rasterizer->getPathApproximator()->approximate($commands);
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         $rasterizer->render('path', array(
             'segments'  => $subpaths,
             'fill-rule' => strtolower(trim($this->getComputedStyle('fill-rule') ?: 'nonzero'))
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/Shapes/SVGPolygon.php
+++ b/src/Nodes/Shapes/SVGPolygon.php
@@ -3,6 +3,7 @@
 namespace SVG\Nodes\Shapes;
 
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 
 /**
  * Represents the SVG tag 'polygon'.
@@ -34,9 +35,13 @@ class SVGPolygon extends SVGPolygonalShape
             return;
         }
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         $rasterizer->render('polygon', array(
             'open'      => false,
             'points'    => $this->getPoints(),
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/Shapes/SVGPolyline.php
+++ b/src/Nodes/Shapes/SVGPolyline.php
@@ -3,6 +3,7 @@
 namespace SVG\Nodes\Shapes;
 
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 
 /**
  * Represents the SVG tag 'polyline'.
@@ -34,9 +35,13 @@ class SVGPolyline extends SVGPolygonalShape
             return;
         }
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         $rasterizer->render('polygon', array(
             'open'      => true,
             'points'    => $this->getPoints(),
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -4,6 +4,7 @@ namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 use SVG\Utilities\Units\Length;
 
 /**
@@ -160,6 +161,8 @@ class SVGRect extends SVGNodeContainer
             return;
         }
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         $rasterizer->render('rect', array(
             'x'         => Length::convert($this->getX(), $rasterizer->getDocumentWidth()),
             'y'         => Length::convert($this->getY(), $rasterizer->getDocumentHeight()),
@@ -168,5 +171,7 @@ class SVGRect extends SVGNodeContainer
             'rx'        => Length::convert($this->getRX(), $rasterizer->getDocumentWidth()),
             'ry'        => Length::convert($this->getRY(), $rasterizer->getDocumentHeight()),
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/Texts/SVGText.php
+++ b/src/Nodes/Texts/SVGText.php
@@ -5,6 +5,7 @@ namespace SVG\Nodes\Texts;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Nodes\Structures\SVGFont;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 use SVG\Utilities\Units\Length;
 
 /**
@@ -92,6 +93,8 @@ class SVGText extends SVGNodeContainer
             return;
         }
 
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+
         // TODO: support percentage font sizes
         //       https://www.w3.org/TR/SVG11/text.html#FontSizeProperty
         //       "Percentages: refer to parent element's font size"
@@ -106,5 +109,7 @@ class SVGText extends SVGNodeContainer
             'text'      => $this->getValue(),
             'font_path' => $this->font->getFontPath(),
         ), $this);
+
+        $rasterizer->popTransform();
     }
 }

--- a/src/Rasterization/Renderers/ImageRenderer.php
+++ b/src/Rasterization/Renderers/ImageRenderer.php
@@ -23,7 +23,7 @@ class ImageRenderer extends Renderer
      */
     public function render(SVGRasterizer $rasterizer, array $options, SVGNode $context)
     {
-        $transform = $rasterizer->makeTransform();
+        $transform = $rasterizer->getCurrentTransform();
 
         $x      = $options['x'];
         $y      = $options['y'];

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -20,7 +20,7 @@ abstract class MultiPassRenderer extends Renderer
      */
     public function render(SVGRasterizer $rasterizer, array $options, SVGNode $context)
     {
-        $transform = $rasterizer->makeTransform();
+        $transform = $rasterizer->getCurrentTransform();
 
         $params = $this->prepareRenderParams($options, $transform);
 


### PR DESCRIPTION
The rasterizer obtains a transform stack, which initially contains just
the viewport scale+offset transform. The new methods for pushing to and
popping from that stack are intended to be used by nodes during render.
If a node has a 'transform' attribute, it can call `pushTransform()`,
apply its own transform on top of the previous one, do its rendering
with that, and finally call `popTransform()` to revert to the previous
transform state so that its siblings and ancestors can render correctly
as well.

I also considered passing the parent transform to each node as an
argument of the `SVGNode::rasterize()` method, but that seemed very
messy because we'd have to remember for every node class to properly
clone the transform before mutating it. With this design, there will
still be code duplication, but it's rather straightforward.

Closes #148 