### PR TITLE
refactor: Move path approximation into renderer

### DIFF
--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -63,12 +63,11 @@ class SVGPath extends SVGNodeContainer
         }
 
         $commands = $rasterizer->getPathParser()->parse($d);
-        $subpaths = $rasterizer->getPathApproximator()->approximate($commands);
 
         TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
 
         $rasterizer->render('path', array(
-            'segments'  => $subpaths,
+            'commands'  => $commands,
             'fill-rule' => strtolower(trim($this->getComputedStyle('fill-rule') ?: 'nonzero'))
         ), $this);
 

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -2,6 +2,7 @@
 
 namespace SVG\Rasterization\Renderers;
 
+use SVG\Rasterization\Path\PathApproximator;
 use SVG\Rasterization\Transform\Transform;
 
 /**
@@ -15,15 +16,24 @@ use SVG\Rasterization\Transform\Transform;
  */
 class PathRenderer extends MultiPassRenderer
 {
+    private $pathApproximator;
+
+    public function __construct()
+    {
+        $this->pathApproximator = new PathApproximator();
+    }
+
     /**
      * @inheritdoc
      */
     protected function prepareRenderParams(array $options, Transform $transform)
     {
+        $subpaths = $this->pathApproximator->approximate($options['commands']);
+
         $segments = array();
-        foreach ($options['segments'] as $segment) {
+        foreach ($subpaths as $subpath) {
             $points = array();
-            foreach ($segment as $point) {
+            foreach ($subpath as $point) {
                 $transform->mapInto($point[0], $point[1], $points);
             }
             $segments[] = $points;

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -27,8 +27,6 @@ class SVGRasterizer
     private static $renderers;
     /** @var Path\PathParser The singleton path parser. */
     private static $pathParser;
-    /** @var Path\PathApproximator The singleton path approximator. */
-    private static $pathApproximator;
 
     /**
      * @var float[] The document's viewBox (x, y, w, h).
@@ -148,8 +146,7 @@ class SVGRasterizer
             'text'      => new Renderers\TextRenderer(),
         );
 
-        self::$pathParser       = new Path\PathParser();
-        self::$pathApproximator = new Path\PathApproximator();
+        self::$pathParser = new Path\PathParser();
     }
 
     /**
@@ -176,15 +173,6 @@ class SVGRasterizer
     public function getPathParser()
     {
         return self::$pathParser;
-    }
-
-    /**
-     * @return Path\PathApproximator The approximator used by this instance.
-     */
-    // implementation note: (see 'getPathParser()')
-    public function getPathApproximator()
-    {
-        return self::$pathApproximator;
     }
 
     /**

--- a/tests/Nodes/Shapes/SVGPathTest.php
+++ b/tests/Nodes/Shapes/SVGPathTest.php
@@ -13,16 +13,12 @@ use SVG\Nodes\Shapes\SVGPath;
 class SVGPathTest extends \PHPUnit\Framework\TestCase
 {
     private static $sampleDescription = 'M100,100 h20 Z M200,200 h20';
-    private static $sampleParse = array(
+    private static $sampleCommands = array(
         array('id' => 'M', 'args' => array(100, 100)),
         array('id' => 'h', 'args' => array(20)),
         array('id' => 'Z', 'args' => array()),
         array('id' => 'M', 'args' => array(200, 200)),
         array('id' => 'h', 'args' => array(20)),
-    );
-    private static $sampleApproximate = array(
-        array(array(100, 100), array(120, 100), array(100, 100)),
-        array(array(200, 200), array(220, 200)),
     );
 
     /**
@@ -109,18 +105,13 @@ class SVGPathTest extends \PHPUnit\Framework\TestCase
         // should call path parser with description attribute
         $pathParser->expects($this->once())->method('parse')->with(
             $this->identicalTo(self::$sampleDescription)
-        )->willReturn(self::$sampleParse);
-
-        // should call path approximator with parser's return value
-        $pathApproximator->expects($this->once())->method('approximate')->with(
-            $this->identicalTo(self::$sampleParse)
-        )->willReturn(self::$sampleApproximate);
+        )->willReturn(self::$sampleCommands);
 
         // should call image renderer with correct options
         $rast->expects($this->once())->method('render')->with(
             $this->identicalTo('path'),
             $this->identicalTo(array(
-                'segments' => self::$sampleApproximate,
+                'commands' => self::$sampleCommands,
                 'fill-rule' => 'nonzero',
             )),
             $this->identicalTo($obj)

--- a/tests/Rasterization/SVGRasterizerTest.php
+++ b/tests/Rasterization/SVGRasterizerTest.php
@@ -27,17 +27,6 @@ class SVGRasterizerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers ::getPathApproximator
-     */
-    public function testGetPathApproximator()
-    {
-        // should return an instance of PathApproximator
-        $obj = new SVGRasterizer(10, 20, null, 100, 200);
-        $this->assertInstanceOf('\SVG\Rasterization\Path\PathApproximator', $obj->getPathApproximator());
-        imagedestroy($obj->getImage());
-    }
-
-    /**
      * @covers ::getDocumentWidth
      */
     public function testGetDocumentWidth()


### PR DESCRIPTION
This improves separation of concern between the path element and the
path renderer. The element should not be concerned with how the commands
get turned into points. By moving this logic into the renderer, we
enable a potential future re-implementation where the path approximator
can take into account the current transform to determine its required
accuracy, which would take care of issue #86, among other things such
as generally improved visual fidelity and performance.