### PR TITLE
refactor: Make PathApproximator explicitly stateful

### DIFF
--- a/src/Rasterization/Path/PathApproximator.php
+++ b/src/Rasterization/Path/PathApproximator.php
@@ -65,10 +65,9 @@ class PathApproximator
 
     /**
      * Traces/approximates the path described by the given array of commands.
-     * Calling this multiple times with command arrays C0, C1, ..., Cn is equivalent to calling it once with a single
-     * array that is the concatenation of C0, ..., Cn.
+     * The behavior when this is called multiple times is unspecified.
      *
-     * After the path is fully approximated, the resulting subpaths can be obtained via <code>getSubpaths()</code>.
+     * After this function has completed, the resulting subpaths can be obtained via <code>getSubpaths()</code>.
      *
      * Example input:
      * ```php

--- a/src/Rasterization/Path/PathApproximator.php
+++ b/src/Rasterization/Path/PathApproximator.php
@@ -148,9 +148,7 @@ class PathApproximator
             $this->previousCommand = $id;
         }
 
-        $pos  = $builder->getPosition();
-        $posX = $pos[0];
-        $posY = $pos[1];
+        list($posX, $posY) = $builder->getPosition();
 
         return $builder->build();
     }

--- a/src/Rasterization/Path/PathApproximator.php
+++ b/src/Rasterization/Path/PathApproximator.php
@@ -164,7 +164,7 @@ class PathApproximator
      *
      * @return float[] The reflected point (x, y).
      */
-    private static function reflectPoint($p, $r)
+    private static function reflectPoint(array $p, array $r)
     {
         return array(
             2 * $r[0] - $p[0],
@@ -184,7 +184,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function moveTo($id, $args, PolygonBuilder $builder)
+    private function moveTo($id, array $args, PolygonBuilder $builder)
     {
         if ($id === 'm') {
             $builder->addPointRelative($args[0], $args[1]);
@@ -205,7 +205,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function lineTo($id, $args, PolygonBuilder $builder)
+    private function lineTo($id, array $args, PolygonBuilder $builder)
     {
         if ($id === 'l') {
             $builder->addPointRelative($args[0], $args[1]);
@@ -226,7 +226,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function lineToHorizontal($id, $args, PolygonBuilder $builder)
+    private function lineToHorizontal($id, array $args, PolygonBuilder $builder)
     {
         if ($id === 'h') {
             $builder->addPointRelative($args[0], null);
@@ -247,7 +247,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function lineToVertical($id, $args, PolygonBuilder $builder)
+    private function lineToVertical($id, array $args, PolygonBuilder $builder)
     {
         if ($id === 'v') {
             $builder->addPointRelative(null, $args[0]);
@@ -268,7 +268,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function curveToCubic($id, $args, PolygonBuilder $builder)
+    private function curveToCubic($id, array $args, PolygonBuilder $builder)
     {
         $p0 = $builder->getPosition();
         $p1 = array($args[0], $args[1]);
@@ -304,7 +304,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function curveToCubicSmooth($id, $args, PolygonBuilder $builder)
+    private function curveToCubicSmooth($id, array $args, PolygonBuilder $builder)
     {
         $p0 = $builder->getPosition();
         $p1 = $p0; // first control point defaults to current point
@@ -343,7 +343,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function curveToQuadratic($id, $args, PolygonBuilder $builder)
+    private function curveToQuadratic($id, array $args, PolygonBuilder $builder)
     {
         $p0 = $builder->getPosition();
         $p1 = array($args[0], $args[1]);
@@ -375,7 +375,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function curveToQuadraticSmooth($id, $args, PolygonBuilder $builder)
+    private function curveToQuadraticSmooth($id, array $args, PolygonBuilder $builder)
     {
         $p0 = $builder->getPosition();
         $p1 = $p0; // control point defaults to current point
@@ -410,7 +410,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function arcTo($id, $args, PolygonBuilder $builder)
+    private function arcTo($id, array $args, PolygonBuilder $builder)
     {
         // start point, end point
         $p0 = $builder->getPosition();
@@ -444,7 +444,7 @@ class PathApproximator
      * @SuppressWarnings("unused")
      * @noinspection PhpUnusedPrivateMethodInspection
      */
-    private function closePath($id, $args, PolygonBuilder $builder)
+    private function closePath($id, array $args, PolygonBuilder $builder)
     {
         $first = $builder->getFirstPoint();
         $builder->addPoint($first[0], $first[1]);

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -19,19 +19,15 @@ use SVG\Rasterization\Transform\Transform;
  */
 class PathRenderer extends MultiPassRenderer
 {
-    private $pathApproximator;
-
-    public function __construct()
-    {
-        $this->pathApproximator = new PathApproximator();
-    }
-
     /**
      * @inheritdoc
      */
     protected function prepareRenderParams(array $options, Transform $transform)
     {
-        $subpaths = $this->pathApproximator->approximate($options['commands']);
+        $approximator = new PathApproximator();
+        $approximator->approximate($options['commands']);
+
+        $subpaths = $approximator->getSubpaths();
 
         $segments = array();
         foreach ($subpaths as $subpath) {

--- a/tests/Rasterization/Path/PathApproximatorTest.php
+++ b/tests/Rasterization/Path/PathApproximatorTest.php
@@ -20,7 +20,8 @@ class PathApproximatorTest extends \PHPUnit\Framework\TestCase
             array('id' => 'l', 'args' => array(40, 20)),
             array('id' => 'Z', 'args' => array()),
         );
-        $result = $approx->approximate($cmds);
+        $approx->approximate($cmds);
+        $result = $approx->getSubpaths();
 
         $this->assertSame(10, $result[0][0][0]);
         $this->assertSame(20, $result[0][0][1]);


### PR DESCRIPTION
PathApproximator is already keeping some state such as $previousCommand
that is only valid for the currently-processed path. There is the risk
of unexpected results when rendering multiple paths in a row, where the
later paths are affected by state that was not properly reset. By making
the class be explicit about its stateful nature and requiring one
instance per path data, these problems are avoided.