### PR TITLE
feat: Rewrite PathApproximator to take the Transform into account

### DIFF
--- a/src/Rasterization/Path/BezierApproximator.php
+++ b/src/Rasterization/Path/BezierApproximator.php
@@ -30,7 +30,7 @@ class BezierApproximator
 
         $step = 0.1;
 
-        while ($t < 1) {
+        while (true) {
             do {
                 $step *= 2;
                 $point = self::calculateQuadratic($p0, $p1, $p2, $t + $step);
@@ -43,9 +43,15 @@ class BezierApproximator
                 $dist  = self::getDistanceSquared($prev, $point);
             } while ($dist > $accuracy);
 
-            $points[] = $prev = $point;
             $t += $step;
+            if ($t >= 1) {
+                // final point is appended manually to achieve perfect accuracy
+                break;
+            }
+            $points[] = $prev = $point;
         }
+
+        $points[] = $p2;
 
         return $points;
     }
@@ -73,7 +79,7 @@ class BezierApproximator
 
         $step  = 0.1;
 
-        while ($t < 1) {
+        while (true) {
             do {
                 $step *= 2;
                 $point = self::calculateCubic($p0, $p1, $p2, $p3, $t + $step);
@@ -86,9 +92,15 @@ class BezierApproximator
                 $dist  = self::getDistanceSquared($prev, $point);
             } while ($dist > $accuracy);
 
-            $points[] = $prev = $point;
             $t += $step;
+            if ($t >= 1) {
+                // final point is appended manually to achieve perfect accuracy
+                break;
+            }
+            $points[] = $prev = $point;
         }
+
+        $points[] = $p3;
 
         return $points;
     }

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -24,16 +24,15 @@ class PathRenderer extends MultiPassRenderer
      */
     protected function prepareRenderParams(array $options, Transform $transform)
     {
-        $approximator = new PathApproximator();
+        $approximator = new PathApproximator($transform);
         $approximator->approximate($options['commands']);
 
-        $subpaths = $approximator->getSubpaths();
-
         $segments = array();
-        foreach ($subpaths as $subpath) {
+        foreach ($approximator->getSubpaths() as $subpath) {
             $points = array();
             foreach ($subpath as $point) {
-                $transform->mapInto($point[0], $point[1], $points);
+                $points[] = $point[0];
+                $points[] = $point[1];
             }
             $segments[] = $points;
         }

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -48,10 +48,6 @@ class PathRenderer extends MultiPassRenderer
      */
     protected function renderFill($image, array $params, $color)
     {
-        if (empty($params['segments']) || count($params['segments'][0]) < 2) {
-            return;
-        }
-
         imagesetthickness($image, 1);
 
         // whether to use the evenodd rule (vs. nonzero winding)
@@ -80,6 +76,11 @@ class PathRenderer extends MultiPassRenderer
                 $edges[] = $edge;
             }
         }
+
+        if (count($edges) < 3) {
+            return;
+        }
+
         // Sort the edges by their maximum y value, descending (i.e., edges that extend further down are sorted first).
         usort($edges, array('SVG\Rasterization\Renderers\PathRendererEdge', 'compareMaxY'));
         // Now the maxY of the entire path is just the maxY of the edge sorted first.

--- a/tests/Rasterization/Path/PathApproximatorTest.php
+++ b/tests/Rasterization/Path/PathApproximatorTest.php
@@ -204,6 +204,255 @@ class PathApproximatorTest extends \PHPUnit\Framework\TestCase
         ), $approx->getSubpaths());
     }
 
+    public function testCurveToCubic()
+    {
+        // Simple test: draw cubic curves representing straight lines
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'C', 'args' => array(12, 20, 18, 20, 20, 20)),
+            array('id' => 'c', 'args' => array(0, 2, 0, 8, 0, 10)),
+        ));
+        $subpaths = $approx->getSubpaths();
+        $this->assertCount(1, $subpaths);
+        $this->assertGreaterThan(10, count($subpaths[0]));
+        // check end points
+        $this->assertEquals(array(10, 20), $subpaths[0][0]);
+        $this->assertEquals(array(20, 30), $subpaths[0][count($subpaths[0]) - 1]);
+        // find the index of the corner (end point of the first CurveToCubic command)
+        for ($corner = 0; $corner < count($subpaths[0]) && $subpaths[0][$corner] != array(20, 20);) {
+            ++$corner;
+        }
+        // expect it to be in the middle
+        $this->assertGreaterThan(0.4 * count($subpaths[0]), $corner);
+        $this->assertLessThan(0.6 * count($subpaths[0]), $corner);
+        // expect everything before to be a straight horizontal line
+        for ($i = 1; $i <= $corner; ++$i) {
+            list($xPrev, $yPrev) = $subpaths[0][$i - 1];
+            list($x, $y) = $subpaths[0][$i];
+            $this->assertGreaterThanOrEqual($xPrev, $x);
+            $this->assertLessThanOrEqual(20, $x);
+            $this->assertEquals($yPrev, $y);
+        }
+        // expect everything after to be a straight vertical line
+        for ($i = $corner + 1; $i < count($subpaths[0]); ++$i) {
+            list($xPrev, $yPrev) = $subpaths[0][$i - 1];
+            list($x, $y) = $subpaths[0][$i];
+            $this->assertEquals($xPrev, $x);
+            $this->assertGreaterThanOrEqual($yPrev, $y);
+            $this->assertLessThanOrEqual(30, $y);
+        }
+
+        // Ensure that with larger transform scale, the number of points increases (but not by too much)
+        $transform = Transform::identity();
+        $transform->scale(4, 4);
+        $approx = new PathApproximator($transform);
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'C', 'args' => array(12, 20, 18, 20, 20, 20)),
+            array('id' => 'c', 'args' => array(0, 2, 0, 8, 0, 10)),
+        ));
+        $subpaths2 = $approx->getSubpaths();
+        $this->assertGreaterThan(3.5 * count($subpaths[0]), count($subpaths2[0]));
+        $this->assertLessThan(4.5 * count($subpaths[0]), count($subpaths2[0]));
+    }
+
+    public function testCurveToCubicSmooth()
+    {
+        // without preceding CurveToCubic
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'S', 'args' => array(15, 30, 20, 20)),
+        ));
+        $subpaths = $approx->getSubpaths();
+        $this->assertCount(1, $subpaths);
+        $this->assertGreaterThan(10, count($subpaths[0]));
+        // check end points
+        $this->assertEquals(array(10, 20), $subpaths[0][0]);
+        $this->assertEquals(array(20, 20), $subpaths[0][count($subpaths[0]) - 1]);
+        // check center (the curve should bend downwards about halfway to the only control point)
+        list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) / 2)];
+        $this->assertEquals(15, $x, null, 1.0);
+        $this->assertEquals(25, $y, null, 1.0);
+
+        // with preceding CurveToCubic (test reflection of control point)
+        // this also checks the relative variant
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'C', 'args' => array(14, 30, 16, 30, 20, 20)),
+            array('id' => 's', 'args' => array(6, -10, 10, 0)),
+        ));
+        $subpaths = $approx->getSubpaths();
+        $this->assertCount(1, $subpaths);
+        $this->assertGreaterThan(10, count($subpaths[0]));
+        // check end points
+        $this->assertEquals(array(10, 20), $subpaths[0][0]);
+        $this->assertEquals(array(30, 20), $subpaths[0][count($subpaths[0]) - 1]);
+        // The curve should first bend down due to 'C', then bend up due to the reflected 's'.
+        // - check at 1/4 from beginning
+        list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) * 0.25)];
+        $this->assertEquals(15, $x, null, 1.0);
+        $this->assertEquals(27.5, $y, null, 1.0);
+        // - check at 1/2 from beginning
+        list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) * 0.5)];
+        $this->assertEquals(20, $x, null, 1.0);
+        $this->assertEquals(20, $y, null, 1.0);
+        // - check at 3/4 from beginning
+        list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) * 0.75)];
+        $this->assertEquals(25, $x, null, 1.0);
+        $this->assertEquals(12.5, $y, null, 1.0);
+    }
+
+    public function testCurveToQuadratic()
+    {
+        // Simple test: draw quadratic curves representing straight lines
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'Q', 'args' => array(15, 20, 20, 20)),
+            array('id' => 'q', 'args' => array(0, 5, 0, 10)),
+        ));
+        $subpaths = $approx->getSubpaths();
+        $this->assertCount(1, $subpaths);
+        $this->assertGreaterThan(10, count($subpaths[0]));
+        // check end points
+        $this->assertEquals(array(10, 20), $subpaths[0][0]);
+        $this->assertEquals(array(20, 30), $subpaths[0][count($subpaths[0]) - 1]);
+        // find the index of the corner (end point of the first CurveToQuadratic command)
+        for ($corner = 0; $corner < count($subpaths[0]) && $subpaths[0][$corner] != array(20, 20);) {
+            ++$corner;
+        }
+        // expect it to be in the middle
+        $this->assertGreaterThan(0.4 * count($subpaths[0]), $corner);
+        $this->assertLessThan(0.6 * count($subpaths[0]), $corner);
+        // expect everything before to be a straight horizontal line
+        for ($i = 1; $i <= $corner; ++$i) {
+            list($xPrev, $yPrev) = $subpaths[0][$i - 1];
+            list($x, $y) = $subpaths[0][$i];
+            $this->assertGreaterThanOrEqual($xPrev, $x);
+            $this->assertLessThanOrEqual(20, $x);
+            $this->assertEquals($yPrev, $y);
+        }
+        // expect everything after to be a straight vertical line
+        for ($i = $corner + 1; $i < count($subpaths[0]); ++$i) {
+            list($xPrev, $yPrev) = $subpaths[0][$i - 1];
+            list($x, $y) = $subpaths[0][$i];
+            $this->assertEquals($xPrev, $x);
+            $this->assertGreaterThanOrEqual($yPrev, $y);
+            $this->assertLessThanOrEqual(30, $y);
+        }
+
+        // Ensure that with larger transform scale, the number of points increases (but not by too much)
+        $transform = Transform::identity();
+        $transform->scale(4, 4);
+        $approx = new PathApproximator($transform);
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'Q', 'args' => array(15, 20, 20, 20)),
+            array('id' => 'q', 'args' => array(0, 5, 0, 10)),
+        ));
+        $subpaths2 = $approx->getSubpaths();
+        $this->assertGreaterThan(3.5 * count($subpaths[0]), count($subpaths2[0]));
+        $this->assertLessThan(4.5 * count($subpaths[0]), count($subpaths2[0]));
+    }
+
+    public function testCurveToQuadraticSmooth()
+    {
+        // without preceding CurveToQuadratic
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'T', 'args' => array(20, 20)),
+        ));
+        $subpaths = $approx->getSubpaths();
+        $this->assertCount(1, $subpaths);
+        $this->assertGreaterThan(10, count($subpaths[0]));
+        // check end points
+        $this->assertEquals(array(10, 20), $subpaths[0][0]);
+        $this->assertEquals(array(20, 20), $subpaths[0][count($subpaths[0]) - 1]);
+        // check center (the curve should represent a flat horizontal line)
+        list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) / 2)];
+        $this->assertEquals(15, $x, null, 1.0);
+        $this->assertEquals(20, $y, null, 1.0);
+
+        // with preceding CurveToQuadratic (test reflection of control point)
+        // this also checks the relative variant
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'Q', 'args' => array(15, 30, 20, 20)),
+            array('id' => 't', 'args' => array(10, 0)),
+        ));
+        $subpaths = $approx->getSubpaths();
+        $this->assertCount(1, $subpaths);
+        $this->assertGreaterThan(10, count($subpaths[0]));
+        // check end points
+        $this->assertEquals(array(10, 20), $subpaths[0][0]);
+        $this->assertEquals(array(30, 20), $subpaths[0][count($subpaths[0]) - 1]);
+        // The curve should first bend down due to 'Q', then bend up due to the reflected 't'.
+        // - check at 1/4 from beginning
+        list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) * 0.25)];
+        $this->assertEquals(15, $x, null, 1.0);
+        $this->assertEquals(25, $y, null, 1.0);
+        // - check at 1/2 from beginning
+        list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) * 0.5)];
+        $this->assertEquals(20, $x, null, 1.0);
+        $this->assertEquals(20, $y, null, 1.0);
+        // - check at 3/4 from beginning
+        list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) * 0.75)];
+        $this->assertEquals(25, $x, null, 1.0);
+        $this->assertEquals(15, $y, null, 1.0);
+    }
+
+    public function testArcTo()
+    {
+        // Run the following test once for the absolute command and once for the relative command.
+        // The coordinates are chosen so that the output should be equal.
+        $commands = array(
+            array('id' => 'A', 'args' => array(5, 10, 0, 1, 0, 20, 20)),
+            array('id' => 'a', 'args' => array(5, 10, 0, 1, 0, 10, 0)),
+        );
+        foreach ($commands as $command) {
+            $approx = new PathApproximator(Transform::identity());
+            $approx->approximate(array(
+                array('id' => 'M', 'args' => array(10, 20)),
+                $command,
+            ));
+            $subpaths = $approx->getSubpaths();
+            $this->assertCount(1, $subpaths);
+            $this->assertGreaterThan(10, count($subpaths[0]));
+            // check end points
+            $this->assertEquals(array(10, 20), $subpaths[0][0]);
+            $this->assertEquals(array(20, 20), $subpaths[0][count($subpaths[0]) - 1]);
+            // points in between should have x >= 10 && x <= 20 and y >= 20, y <= 30
+            foreach ($subpaths[0] as $point) {
+                list($x, $y) = $point;
+                $this->assertGreaterThanOrEqual(10, $x);
+                $this->assertLessThanOrEqual(20, $x);
+                $this->assertGreaterThanOrEqual(20, $y);
+                $this->assertLessThanOrEqual(30, $y);
+            }
+            // midpoint should roughly be at [15, 30]
+            list($x, $y) = $subpaths[0][ceil(count($subpaths[0]) / 2)];
+            $this->assertEquals(15, $x, null, 0.5);
+            $this->assertEquals(30, $y, null, 0.5);
+        }
+
+        // Ensure that with larger transform scale, the number of points increases (but not by too much)
+        $transform = Transform::identity();
+        $transform->scale(4, 4);
+        $approx = new PathApproximator($transform);
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'A', 'args' => array(5, 10, 0, 1, 0, 20, 20)),
+        ));
+        $subpaths2 = $approx->getSubpaths();
+        $this->assertGreaterThan(3.5 * count($subpaths[0]), count($subpaths2[0]));
+        $this->assertLessThan(4.5 * count($subpaths[0]), count($subpaths2[0]));
+    }
+
     public function testClosePath()
     {
         // try with both 'z' and 'Z', which should behave the same

--- a/tests/Rasterization/Path/PathApproximatorTest.php
+++ b/tests/Rasterization/Path/PathApproximatorTest.php
@@ -12,6 +12,8 @@ use SVG\Rasterization\Transform\Transform;
  */
 class PathApproximatorTest extends \PHPUnit\Framework\TestCase
 {
+    // general tests
+
     public function testApproximate()
     {
         $approx = new PathApproximator(Transform::identity());
@@ -25,9 +27,6 @@ class PathApproximatorTest extends \PHPUnit\Framework\TestCase
         $result = $approx->getSubpaths();
 
         $this->assertSame(array(
-            array(
-                array(10, 20),
-            ),
             array(
                 array(20, 40),
                 array(60, 60),
@@ -53,13 +52,209 @@ class PathApproximatorTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(array(
             array(
-                array(30, 100),
-            ),
-            array(
                 array(60, 200),
                 array(180, 300),
                 array(60, 200),
             ),
         ), $result);
+    }
+
+    // tests more specific to each path command
+
+    public function testMoveTo()
+    {
+        // https://www.w3.org/TR/SVG/paths.html#PathDataMovetoCommands
+        // "A path data segment (if there is one) must begin with a "moveto" command."
+        // If there is no moveto command at the beginning, the approximation should be empty.
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'l', 'args' => array(-5, -7)),
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'L', 'args' => array(37, 41)),
+        ));
+        $this->assertSame(array(), $approx->getSubpaths());
+
+        // MoveTo should not generate points on its own
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'M', 'args' => array(20, 30)),
+            array('id' => 'm', 'args' => array(30, -60)),
+            array('id' => 'm', 'args' => array(-40, -100)),
+        ));
+        $this->assertSame(array(), $approx->getSubpaths());
+    }
+
+    public function testLineTo()
+    {
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'm', 'args' => array(30, 50)),
+            array('id' => 'l', 'args' => array(17, 19)),
+            array('id' => 'L', 'args' => array(37, 41)),
+            array('id' => 'm', 'args' => array(-100, -300)),
+            array('id' => 'l', 'args' => array(19, 23)),
+        ));
+        $this->assertSame(array(
+            array(
+                array(40, 70),
+                array(57, 89),
+                array(37, 41),
+            ),
+            array(
+                array(-63, -259),
+                array(-44, -236),
+            ),
+        ), $approx->getSubpaths());
+
+        // with transform
+        $transform = Transform::identity();
+        $transform->translate(-40, 90);
+        $transform->scale(3, 5);
+        $approx = new PathApproximator($transform);
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'm', 'args' => array(30, 50)),
+            array('id' => 'l', 'args' => array(17, 19)),
+            array('id' => 'L', 'args' => array(37, 41)),
+            array('id' => 'm', 'args' => array(-100, -300)),
+            array('id' => 'l', 'args' => array(19, 23)),
+        ));
+        $this->assertSame(array(
+            array(
+                array(40 * 3 - 40, 70 * 5 + 90),
+                array(57 * 3 - 40, 89 * 5 + 90),
+                array(37 * 3 - 40, 41 * 5 + 90),
+            ),
+            array(
+                array(-63 * 3 - 40, -259 * 5 + 90),
+                array(-44 * 3 - 40, -236 * 5 + 90),
+            ),
+        ), $approx->getSubpaths());
+    }
+
+    public function testLineToHorizontal()
+    {
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'h', 'args' => array(170)),
+            array('id' => 'H', 'args' => array(370)),
+        ));
+        $this->assertSame(array(
+            array(
+                array(10, 20),
+                array(180, 20),
+                array(370, 20),
+            ),
+        ), $approx->getSubpaths());
+
+        // with transform
+        $transform = Transform::identity();
+        $transform->translate(-40, 90);
+        $transform->scale(3, 5);
+        $approx = new PathApproximator($transform);
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'h', 'args' => array(170)),
+            array('id' => 'H', 'args' => array(370)),
+        ));
+        $this->assertSame(array(
+            array(
+                array(10 * 3 - 40, 190),
+                array(180 * 3 - 40, 190),
+                array(370 * 3 - 40, 190),
+            ),
+        ), $approx->getSubpaths());
+    }
+
+    public function testLineToVertical()
+    {
+        $approx = new PathApproximator(Transform::identity());
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'v', 'args' => array(170)),
+            array('id' => 'V', 'args' => array(370)),
+        ));
+        $this->assertSame(array(
+            array(
+                array(10, 20),
+                array(10, 190),
+                array(10, 370),
+            ),
+        ), $approx->getSubpaths());
+
+        // with transform
+        $transform = Transform::identity();
+        $transform->translate(-40, 90);
+        $transform->scale(3, 5);
+        $approx = new PathApproximator($transform);
+        $approx->approximate(array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'v', 'args' => array(170)),
+            array('id' => 'V', 'args' => array(370)),
+        ));
+        $this->assertSame(array(
+            array(
+                array(-10, 20 * 5 + 90),
+                array(-10, 190 * 5 + 90),
+                array(-10, 370 * 5 + 90),
+            ),
+        ), $approx->getSubpaths());
+    }
+
+    public function testClosePath()
+    {
+        // try with both 'z' and 'Z', which should behave the same
+        foreach (array('z', 'Z') as $closeCommand) {
+            $approx = new PathApproximator(Transform::identity());
+            $approx->approximate(array(
+                array('id' => 'M', 'args' => array(10, 20)),
+                array('id' => 'L', 'args' => array(50, 70)),
+                array('id' => $closeCommand, 'args' => array()),
+                array('id' => 'l', 'args' => array(13, 17)),
+            ));
+            $this->assertSame(array(
+                array(
+                    array(10, 20),
+                    array(50, 70),
+                    array(10, 20),
+                ),
+                array(
+                    array(10, 20),
+                    array(23, 37),
+                ),
+            ), $approx->getSubpaths());
+
+            // https://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand
+            // "This path segment may be of zero length."
+            $approx = new PathApproximator(Transform::identity());
+            $approx->approximate(array(
+                array('id' => 'M', 'args' => array(10, 20)),
+                array('id' => $closeCommand, 'args' => array()),
+                array('id' => 'M', 'args' => array(30, 50)),
+                array('id' => 'L', 'args' => array(60, 100)),
+                array('id' => 'L', 'args' => array(30, 50)),
+                array('id' => $closeCommand, 'args' => array()),
+                array('id' => $closeCommand, 'args' => array()),
+            ));
+            $this->assertSame(array(
+                array(
+                    array(10, 20),
+                    array(10, 20),
+                ),
+                array(
+                    array(30, 50),
+                    array(60, 100),
+                    array(30, 50),
+                    array(30, 50),
+                ),
+                array(
+                    array(30, 50),
+                    array(30, 50),
+                ),
+            ), $approx->getSubpaths());
+        }
     }
 }

--- a/tests/Rasterization/Path/PathApproximatorTest.php
+++ b/tests/Rasterization/Path/PathApproximatorTest.php
@@ -59,6 +59,27 @@ class PathApproximatorTest extends \PHPUnit\Framework\TestCase
         ), $result);
     }
 
+    public function testApproximateStopsAtInvalidCommand()
+    {
+        $approx = new PathApproximator(Transform::identity());
+        $cmds = array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'l', 'args' => array(40, 20)),
+            array('id' => 'x', 'args' => array()),
+            array('id' => 'l', 'args' => array(0, 10)),
+            array('id' => 'Z', 'args' => array()),
+        );
+        $approx->approximate($cmds);
+        $result = $approx->getSubpaths();
+
+        $this->assertSame(array(
+            array(
+                array(10, 20),
+                array(50, 40),
+            ),
+        ), $result);
+    }
+
     // tests more specific to each path command
 
     public function testMoveTo()

--- a/tests/Rasterization/Path/PathApproximatorTest.php
+++ b/tests/Rasterization/Path/PathApproximatorTest.php
@@ -3,6 +3,7 @@
 namespace SVG;
 
 use SVG\Rasterization\Path\PathApproximator;
+use SVG\Rasterization\Transform\Transform;
 
 /**
  * @covers \SVG\Rasterization\Path\PathApproximator
@@ -13,7 +14,7 @@ class PathApproximatorTest extends \PHPUnit\Framework\TestCase
 {
     public function testApproximate()
     {
-        $approx = new PathApproximator();
+        $approx = new PathApproximator(Transform::identity());
         $cmds = array(
             array('id' => 'M', 'args' => array(10, 20)),
             array('id' => 'm', 'args' => array(10, 20)),
@@ -23,13 +24,42 @@ class PathApproximatorTest extends \PHPUnit\Framework\TestCase
         $approx->approximate($cmds);
         $result = $approx->getSubpaths();
 
-        $this->assertSame(10, $result[0][0][0]);
-        $this->assertSame(20, $result[0][0][1]);
-        $this->assertSame(20, $result[1][0][0]);
-        $this->assertSame(40, $result[1][0][1]);
-        $this->assertSame(60, $result[1][1][0]);
-        $this->assertSame(60, $result[1][1][1]);
-        $this->assertSame(20, $result[1][2][0]);
-        $this->assertSame(40, $result[1][2][1]);
+        $this->assertSame(array(
+            array(
+                array(10, 20),
+            ),
+            array(
+                array(20, 40),
+                array(60, 60),
+                array(20, 40),
+            ),
+        ), $result);
+    }
+
+    public function testApproximateWithTransform()
+    {
+        $transform = Transform::identity();
+        $transform->scale(3, 5);
+
+        $approx = new PathApproximator($transform);
+        $cmds = array(
+            array('id' => 'M', 'args' => array(10, 20)),
+            array('id' => 'm', 'args' => array(10, 20)),
+            array('id' => 'l', 'args' => array(40, 20)),
+            array('id' => 'Z', 'args' => array()),
+        );
+        $approx->approximate($cmds);
+        $result = $approx->getSubpaths();
+
+        $this->assertSame(array(
+            array(
+                array(30, 100),
+            ),
+            array(
+                array(60, 200),
+                array(180, 300),
+                array(60, 200),
+            ),
+        ), $result);
     }
 }


### PR DESCRIPTION
Fixes #86. Instead of approximating the path first and *then* mapping
the resulting points into image space, they are mapped into image space
first, and then approximated. This means there is exactly the right
amount of visual fidelity, independent of the relationship between path
coordinate space and image coordinate space. If the image is scaled up,
the approximation simply gets more detailed, and if the image is scaled
down, the approximation will also contain fewer points to improve
performance.

This works very nicely for lines and Bézier curves which are invariant
under affine transforms, i.e., there is no downside to changing the
order of operations like this. Yet, I still don't know how to apply the
idea to arcs, which might not be invariant, at least not in SVG's
endpoint representation. Hence, they are still approximated in path
space at the moment. Guessing a scale factor and using it to increase
or decrease the number of arc subdivisions seems like an acceptable
workaround for now.