### PR TITLE
feat: Implement renderer support for 'fill-opacity' and 'stroke-opacity'

### DIFF
--- a/tests/Rasterization/Renderers/MultiPassRendererTest.php
+++ b/tests/Rasterization/Renderers/MultiPassRendererTest.php
@@ -12,6 +12,15 @@ use SVG\Rasterization\Renderers\MultiPassRenderer;
  */
 class MultiPassRendererTest extends \PHPUnit\Framework\TestCase
 {
+    private static $sampleOptions = array(
+        'option1' => 'option1-value',
+        'option2' => 'option2-value',
+    );
+    private static $sampleParams = array(
+        'param1' => 'param1-value',
+        'param2' => 'param2-value',
+    );
+
     // helper function
     private function isGdImage()
     {
@@ -24,66 +33,119 @@ class MultiPassRendererTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testRender()
+    public function testRenderShouldCallPrepare()
     {
-        $rast = new \SVG\Rasterization\SVGRasterizer(10, 20, null, 100, 200);
-        $options = array(
-            'option1' => 'option1-value',
-            'option2' => 'option2-value',
-        );
+        $rasterizer = new \SVG\Rasterization\SVGRasterizer(10, 20, null, 100, 200);
         $node = $this->getMockForAbstractClass('\SVG\Nodes\SVGNode');
-
-        $params = array(
-            'param1' => 'param1-value',
-            'param2' => 'param2-value',
-        );
 
         // should call prepareRenderParams with correct arguments
         $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
         $obj->expects($this->once())->method('prepareRenderParams')->with(
-            $this->identicalTo($options),
+            $this->identicalTo(self::$sampleOptions),
             $this->isInstanceOf('\SVG\Rasterization\Transform\Transform')
-        )->willReturn($params);
-        $obj->render($rast, $options, $node);
+        )->willReturn(self::$sampleParams);
+        $obj->render($rasterizer, self::$sampleOptions, $node);
+
+        imagedestroy($rasterizer->getImage());
+    }
+
+    public function testRenderShouldCallRenderFill()
+    {
+        $rasterizer = new \SVG\Rasterization\SVGRasterizer(10, 20, null, 100, 200);
+        $node = $this->getMockForAbstractClass('\SVG\Nodes\SVGNode');
 
         // should call renderFill with correct fill color
         $node->setStyle('fill', '#AAAAAA');
         $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
-        $obj->method('prepareRenderParams')->willReturn($params);
+        $obj->method('prepareRenderParams')->willReturn(self::$sampleParams);
         $obj->expects($this->once())->method('renderFill')->with(
             $this->isGdImage(),
-            $this->identicalTo($params),
+            $this->identicalTo(self::$sampleParams),
             $this->identicalTo(0xAAAAAA)
         );
-        $obj->render($rast, $options, $node);
+        $obj->render($rasterizer, self::$sampleOptions, $node);
 
         // should not call renderFill with 'fill: none' style
         $node->setStyle('fill', 'none');
         $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
-        $obj->method('prepareRenderParams')->willReturn($params);
+        $obj->method('prepareRenderParams')->willReturn(self::$sampleParams);
         $obj->expects($this->never())->method('renderFill');
-        $obj->render($rast, $options, $node);
+        $obj->render($rasterizer, self::$sampleOptions, $node);
+
+        imagedestroy($rasterizer->getImage());
+    }
+
+    public function testRenderShouldCallRenderStroke()
+    {
+        $rasterizer = new \SVG\Rasterization\SVGRasterizer(10, 20, null, 100, 200);
+        $node = $this->getMockForAbstractClass('\SVG\Nodes\SVGNode');
 
         // should call renderStroke with correct stroke color and width
         $node->setStyle('stroke', '#BBBBBB');
         $node->setStyle('stroke-width', '2px');
         $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
-        $obj->method('prepareRenderParams')->willReturn($params);
+        $obj->method('prepareRenderParams')->willReturn(self::$sampleParams);
         $obj->expects($this->once())->method('renderStroke')->with(
             $this->isGdImage(),
-            $this->identicalTo($params),
+            $this->identicalTo(self::$sampleParams),
             $this->identicalTo(0xBBBBBB),
             $this->equalTo(20)
         );
-        $obj->render($rast, $options, $node);
+        $obj->render($rasterizer, self::$sampleOptions, $node);
 
         // should not call renderStroke with 'stroke: none' style
         $node->setStyle('stroke', 'none');
         $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
-        $obj->method('prepareRenderParams')->willReturn($params);
+        $obj->method('prepareRenderParams')->willReturn(self::$sampleParams);
         $obj->expects($this->never())->method('renderStroke');
-        $obj->render($rast, $options, $node);
+        $obj->render($rasterizer, self::$sampleOptions, $node);
 
-        imagedestroy($rast->getImage());
+        imagedestroy($rasterizer->getImage());
+    }
+
+    public function testRenderShouldRespectFillOpacity()
+    {
+        $rasterizer = new \SVG\Rasterization\SVGRasterizer(10, 20, null, 100, 200);
+        $node = $this->getMockForAbstractClass('\SVG\Nodes\SVGNode');
+
+        // should use fill-opacity for the alpha value (try with a few different notations)
+        foreach (array('0.5', '.5', '50%', '  0.5  ', '  50%  ') as $fillOpacity) {
+            $node->setStyle('fill', '#AAAAAA');
+            $node->setStyle('fill-opacity', $fillOpacity);
+            $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
+            $obj->method('prepareRenderParams')->willReturn(self::$sampleParams);
+            $obj->expects($this->once())->method('renderFill')->with(
+                $this->isGdImage(),
+                $this->identicalTo(self::$sampleParams),
+                $this->identicalTo(0x3FAAAAAA)
+            );
+            $obj->render($rasterizer, self::$sampleOptions, $node);
+        }
+
+        imagedestroy($rasterizer->getImage());
+    }
+
+    public function testRenderShouldRespectStrokeOpacity()
+    {
+        $rasterizer = new \SVG\Rasterization\SVGRasterizer(10, 20, null, 100, 200);
+        $node = $this->getMockForAbstractClass('\SVG\Nodes\SVGNode');
+
+        // should use stroke-opacity for the alpha value (try with a few different notations)
+        foreach (array('0.5', '.5', '50%', '  0.5  ', '  50%  ') as $strokeOpacity) {
+            $node->setStyle('stroke', '#BBBBBB');
+            $node->setStyle('stroke-opacity', $strokeOpacity);
+            $node->setStyle('stroke-width', '2px');
+            $obj = $this->getMockForAbstractClass('\SVG\Rasterization\Renderers\MultiPassRenderer');
+            $obj->method('prepareRenderParams')->willReturn(self::$sampleParams);
+            $obj->expects($this->once())->method('renderStroke')->with(
+                $this->isGdImage(),
+                $this->identicalTo(self::$sampleParams),
+                $this->identicalTo(0x3FBBBBBB),
+                $this->equalTo(20)
+            );
+            $obj->render($rasterizer, self::$sampleOptions, $node);
+        }
+
+        imagedestroy($rasterizer->getImage());
     }
 }


### PR DESCRIPTION
Closes #117. In addition to implementing these two attributes, parsing
of the 'opacity' attribute is also improved: It can now deal with
whitespace surrounding the value, and with percentages.