### PR TITLE
fix: Ensure style properties do not contain surrounding whitespace

### DIFF
--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -83,7 +83,8 @@ abstract class SVGNode
     }
 
     /**
-     * Obtains the style with the given name as specified on this node.
+     * Obtains the style with the given name as specified on this node. The return value, if present, will never
+     * contain any leading or trailing whitespace.
      *
      * @param string $name The name of the style to get.
      *
@@ -91,12 +92,14 @@ abstract class SVGNode
      */
     public function getStyle($name)
     {
+        // whitespace has been trimmed in the setter
         return isset($this->styles[$name]) ? $this->styles[$name] : null;
     }
 
     /**
-     * Defines a style on this node. A value of null or the empty string will
-     * unset the property.
+     * Defines a style on this node. A value of null, the empty string, or strings containing only whitespace will
+     * unset the property. Since whitespace surrounding style values is meaningless, it will be trimmed such that later
+     * retrieval of the style property or computed style property will yield the value with no surrounding whitespace.
      *
      * @param string      $name  The name of the style to set.
      * @param string|null $value The new style value.
@@ -105,7 +108,7 @@ abstract class SVGNode
      */
     public function setStyle($name, $value)
     {
-        $value = (string) $value;
+        $value = trim($value);
         if (strlen($value) === 0) {
             unset($this->styles[$name]);
             return $this;
@@ -128,8 +131,10 @@ abstract class SVGNode
     }
 
     /**
-     * Obtains the computed style with the given name. The 'computed style' is
-     * the one in effect; taking inheritance and default styles into account.
+     * Obtains the computed style with the given name. The 'computed style' is the one in effect; taking inheritance
+     * and default styles into account.
+     *
+     * The return value, if present, will never contain any leading or trailing whitespace.
      *
      * @param string $name The name of the style to compute.
      *

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -71,7 +71,7 @@ class SVGPath extends SVGNodeContainer
 
         $rasterizer->render('path', array(
             'commands'  => $commands,
-            'fill-rule' => strtolower(trim($this->getComputedStyle('fill-rule') ?: 'nonzero'))
+            'fill-rule' => strtolower($this->getComputedStyle('fill-rule') ?: 'nonzero')
         ), $this);
 
         $rasterizer->popTransform();

--- a/src/Nodes/Shapes/SVGPolygon.php
+++ b/src/Nodes/Shapes/SVGPolygon.php
@@ -40,7 +40,7 @@ class SVGPolygon extends SVGPolygonalShape
         $rasterizer->render('polygon', array(
             'open'      => false,
             'points'    => $this->getPoints(),
-            'fill-rule' => strtolower(trim($this->getComputedStyle('fill-rule') ?: 'nonzero'))
+            'fill-rule' => strtolower($this->getComputedStyle('fill-rule') ?: 'nonzero')
         ), $this);
 
         $rasterizer->popTransform();

--- a/src/Nodes/Shapes/SVGPolyline.php
+++ b/src/Nodes/Shapes/SVGPolyline.php
@@ -40,7 +40,7 @@ class SVGPolyline extends SVGPolygonalShape
         $rasterizer->render('polygon', array(
             'open'      => true,
             'points'    => $this->getPoints(),
-            'fill-rule' => strtolower(trim($this->getComputedStyle('fill-rule') ?: 'nonzero'))
+            'fill-rule' => strtolower($this->getComputedStyle('fill-rule') ?: 'nonzero')
         ), $this);
 
         $rasterizer->popTransform();

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -171,7 +171,7 @@ abstract class MultiPassRenderer extends Renderer
      */
     private static function getNodeOpacity(SVGNode $node)
     {
-        $opacity = trim($node->getStyle('opacity'));
+        $opacity = $node->getStyle('opacity');
 
         if ($opacity === 'inherit') {
             $parent = $node->getParent();
@@ -209,21 +209,19 @@ abstract class MultiPassRenderer extends Renderer
      * @param string|null $attributeValue The raw attribute value.
      * @return float|int The parsed alpha value in the range 0 to 1. Invalid inputs are mapped to 1.
      */
-    private static function parseOpacity($attributeValue)
+    private static function parseOpacity($value)
     {
         // https://svgwg.org/svg2-draft/render.html#ObjectAndGroupOpacityProperties
         // https://drafts.csswg.org/css-color/#transparency
 
-        $attributeString = trim($attributeValue);
-
         // real numbers
-        if (is_numeric($attributeString)) {
-            return (float) $attributeString;
+        if (is_numeric($value)) {
+            return (float) $value;
         }
 
         // percentages
         $matches = array();
-        if (preg_match('/^([+-]?\d+(?:\.\d+)?|\.\d+)%$/', $attributeString, $matches)) {
+        if (preg_match('/^([+-]?\d+(?:\.\d+)?|\.\d+)%$/', $value, $matches)) {
             return max(0, min(100, $matches[1])) / 100;
         }
 

--- a/tests/Nodes/SVGNodeTest.php
+++ b/tests/Nodes/SVGNodeTest.php
@@ -99,12 +99,23 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         $obj->setStyle('fill', '#FFFFFF');
         $this->assertSame('#FFFFFF', $obj->getStyle('fill'));
 
+        // should trim whitespace around the value
+        $obj->setStyle('fill', "  \n #FFFFFF \n  ");
+        $this->assertSame('#FFFFFF', $obj->getStyle('fill'));
+
         // should unset properties when given null
+        $obj->setStyle('fill', '#FFFFFF');
         $obj->setStyle('fill', null);
         $this->assertNull($obj->getStyle('fill'));
 
         // should unset properties when given ''
+        $obj->setStyle('fill', '#FFFFFF');
         $obj->setStyle('fill', '');
+        $this->assertNull($obj->getStyle('fill'));
+
+        // should unset properties when given a whitespace-only string
+        $obj->setStyle('fill', '#FFFFFF');
+        $obj->setStyle('fill', "  \n  ");
         $this->assertNull($obj->getStyle('fill'));
 
         // should convert value to a string
@@ -257,9 +268,19 @@ class SVGNodeTest extends \PHPUnit\Framework\TestCase
         // should return null for ill-formed viewBox
         $obj->setAttribute('viewBox', 'foobar');
         $this->assertNull($obj->getViewBox());
+        $obj->setAttribute('viewBox', '37 42.25');
+        $this->assertNull($obj->getViewBox());
+        $obj->setAttribute('viewBox', '37, , , ');
+        $this->assertNull($obj->getViewBox());
 
         // should return float array for well-formed viewBox
         $obj->setAttribute('viewBox', '37, 42.25, 100 200');
+        $this->assertSame(array(37.0, 42.25, 100.0, 200.0), $obj->getViewBox());
+        $obj->setAttribute('viewBox', '37, .25, 100 200');
+        $this->assertSame(array(37.0, 0.25, 100.0, 200.0), $obj->getViewBox());
+
+        // should ignore superfluous whitespace
+        $obj->setAttribute('viewBox', "  \n 37, 42.25,\n 100 200 \n  ");
         $this->assertSame(array(37.0, 42.25, 100.0, 200.0), $obj->getViewBox());
     }
 }

--- a/tests/Nodes/Shapes/SVGPathTest.php
+++ b/tests/Nodes/Shapes/SVGPathTest.php
@@ -114,4 +114,41 @@ class SVGPathTest extends \PHPUnit\Framework\TestCase
         $obj->setStyle('visibility', 'collapse');
         $obj->rasterize($rast);
     }
+
+    /**
+     * @covers ::rasterize
+     */
+    public function testRasterizeShouldRespectFillRule()
+    {
+        $obj = new SVGPath(self::$sampleDescription);
+
+        $attributeToExpectedFillRule = array(
+            '' => 'nonzero',
+            " \n " => 'nonzero',
+            'nonzero' => 'nonzero',
+            '  nonzero  ' => 'nonzero',
+            'nonZero' => 'nonzero',
+            'evenodd' => 'evenodd',
+            '  evenodd  ' => 'evenodd',
+            ' evenOdd ' => 'evenodd',
+            'foo' => 'foo',
+        );
+        foreach ($attributeToExpectedFillRule as $attribute => $expectedFillRule) {
+            $rasterizer = $this->getMockBuilder('\SVG\Rasterization\SVGRasterizer')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            $rasterizer->expects($this->once())->method('render')->with(
+                $this->identicalTo('path'),
+                $this->equalTo(array(
+                    'commands' => self::$sampleCommands,
+                    'fill-rule' => $expectedFillRule,
+                )),
+                $this->identicalTo($obj)
+            );
+
+            $obj->setStyle('fill-rule', $attribute);
+            $obj->rasterize($rasterizer);
+        }
+    }
 }

--- a/tests/Nodes/Shapes/SVGPolygonTest.php
+++ b/tests/Nodes/Shapes/SVGPolygonTest.php
@@ -69,4 +69,47 @@ class SVGPolygonTest extends \PHPUnit\Framework\TestCase
         $obj->setStyle('visibility', 'collapse');
         $obj->rasterize($rast);
     }
+
+    /**
+     * @covers ::rasterize
+     */
+    public function testRasterizeShouldRespectFillRule()
+    {
+        $points = array(
+            array(42.5, 42.5),
+            array(37, 37),
+        );
+
+        $obj = new SVGPolygon($points);
+
+        $attributeToExpectedFillRule = array(
+            '' => 'nonzero',
+            " \n " => 'nonzero',
+            'nonzero' => 'nonzero',
+            '  nonzero  ' => 'nonzero',
+            'nonZero' => 'nonzero',
+            'evenodd' => 'evenodd',
+            '  evenodd  ' => 'evenodd',
+            ' evenOdd ' => 'evenodd',
+            'foo' => 'foo',
+        );
+        foreach ($attributeToExpectedFillRule as $attribute => $expectedFillRule) {
+            $rasterizer = $this->getMockBuilder('\SVG\Rasterization\SVGRasterizer')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            $rasterizer->expects($this->once())->method('render')->with(
+                $this->identicalTo('polygon'),
+                $this->equalTo(array(
+                    'open' => false,
+                    'points' => $points,
+                    'fill-rule' => $expectedFillRule,
+                )),
+                $this->identicalTo($obj)
+            );
+
+            $obj->setStyle('fill-rule', $attribute);
+            $obj->rasterize($rasterizer);
+        }
+    }
 }

--- a/tests/Nodes/Shapes/SVGPolylineTest.php
+++ b/tests/Nodes/Shapes/SVGPolylineTest.php
@@ -69,4 +69,47 @@ class SVGPolylineTest extends \PHPUnit\Framework\TestCase
         $obj->setStyle('visibility', 'collapse');
         $obj->rasterize($rast);
     }
+
+    /**
+     * @covers ::rasterize
+     */
+    public function testRasterizeShouldRespectFillRule()
+    {
+        $points = array(
+            array(42.5, 42.5),
+            array(37, 37),
+        );
+
+        $obj = new SVGPolyline($points);
+
+        $attributeToExpectedFillRule = array(
+            '' => 'nonzero',
+            " \n " => 'nonzero',
+            'nonzero' => 'nonzero',
+            '  nonzero  ' => 'nonzero',
+            'nonZero' => 'nonzero',
+            'evenodd' => 'evenodd',
+            '  evenodd  ' => 'evenodd',
+            ' evenOdd ' => 'evenodd',
+            'foo' => 'foo',
+        );
+        foreach ($attributeToExpectedFillRule as $attribute => $expectedFillRule) {
+            $rasterizer = $this->getMockBuilder('\SVG\Rasterization\SVGRasterizer')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            $rasterizer->expects($this->once())->method('render')->with(
+                $this->identicalTo('polygon'),
+                $this->equalTo(array(
+                    'open' => true,
+                    'points' => $points,
+                    'fill-rule' => $expectedFillRule,
+                )),
+                $this->identicalTo($obj)
+            );
+
+            $obj->setStyle('fill-rule', $attribute);
+            $obj->rasterize($rasterizer);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #160. SVGNode::setStyle is modified to trim the input before
storing it, effectively guaranteeing that styles never have leading or
trailing whitespace. Tests are added and/or adapted to look out for this
behavior. Some code could be simplified by removing manual trimming
after retrieval of the style value, since this is no longer needed.