### PR TITLE
fix: Avoid path stroke crash with too few points

### DIFF
--- a/src/Rasterization/Renderers/PathRendererImplementation.php
+++ b/src/Rasterization/Renderers/PathRendererImplementation.php
@@ -171,7 +171,15 @@ final class PathRendererImplementation
      */
     public static function strokeClosedSubpath($image, array $points, $color, $strokeWidth)
     {
+        // imagepolygon() requires at least 3 coordinate pairs
+        if (count($points) < 6) {
+            self::strokeOpenSubpath($image, $points, $color, $strokeWidth);
+            return;
+        }
+
+        $roundedCoordinates = array_map('round', $points);
+
         imagesetthickness($image, round($strokeWidth));
-        imagepolygon($image, $points, count($points) / 2, $color);
+        imagepolygon($image, $roundedCoordinates, count($roundedCoordinates) / 2, $color);
     }
 }

--- a/src/Rasterization/Renderers/PathRendererImplementation.php
+++ b/src/Rasterization/Renderers/PathRendererImplementation.php
@@ -142,6 +142,11 @@ final class PathRendererImplementation
      */
     public static function strokeOpenSubpath($image, array $points, $color, $strokeWidth)
     {
+        // require at least 2 coordinate pairs to stroke a line
+        if (count($points) < 4) {
+            return;
+        }
+
         imagesetthickness($image, round($strokeWidth));
 
         $px = round($points[0]);

--- a/tests/Rasterization/Renderers/PolygonRendererTest.php
+++ b/tests/Rasterization/Renderers/PolygonRendererTest.php
@@ -17,7 +17,7 @@ class PolygonRendererTest extends \PHPUnit\Framework\TestCase
     public function testShouldNotFailForTooFewPoints()
     {
         // ensures that there is no crash in case fewer than 3 points are provided,
-        // which might trip up the fill algorithm if it doesn't check for it
+        // which might trip up the fill or stroke algorithms if they don't check for it
 
         $obj = new PolygonRenderer();
 

--- a/tests/Rasterization/Renderers/PolygonRendererTest.php
+++ b/tests/Rasterization/Renderers/PolygonRendererTest.php
@@ -24,6 +24,7 @@ class PolygonRendererTest extends \PHPUnit\Framework\TestCase
         $context = $this->getMockForAbstractClass('\SVG\Nodes\SVGNode');
         $context->setStyle('fill', '#FF0000');
         $context->setStyle('stroke', '#0000FF');
+        $context->setStyle('stroke-width', '1px');
 
         $rasterizer = new SVGRasterizer('50px', '50px', null, 50, 50);
 


### PR DESCRIPTION
PR #164 fixed a path and polygon crash when filling shapes that have too few points in them.
This PR fixes a potential crash when drawing the stroke in these scenarios.

(That should have been part of the previous PR, but was not noticed due to a mistake in the unit test.)