### PR TITLE
fix: Avoid deprecation warnings when passing null

### DIFF
--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -274,7 +274,7 @@ abstract class SVGNode
      */
     public function getViewBox()
     {
-        if ($this->getAttribute('viewBox') == null ){
+        if ($this->getAttribute('viewBox') == null) {
             return null;
         }
         $attr = trim($this->getAttribute('viewBox'));

--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -249,8 +249,8 @@ abstract class SVGNode
      */
     public function getIdAndClassPattern()
     {
-        $id = trim($this->getAttribute('id'));
-        $class = trim($this->getAttribute('class'));
+        $id = $this->getAttribute('id') != null ? trim($this->getAttribute('id')) : '';
+        $class = $this->getAttribute('class') != null  ? trim($this->getAttribute('class')) : '';
 
         $pattern = '';
         if ($id !== '') {
@@ -274,6 +274,9 @@ abstract class SVGNode
      */
     public function getViewBox()
     {
+        if ($this->getAttribute('viewBox') == null ){
+            return null;
+        }
         $attr = trim($this->getAttribute('viewBox'));
         $result = preg_split('/[\s,]+/', $attr);
         if (count($result) !== 4) {

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -214,6 +214,11 @@ abstract class MultiPassRenderer extends Renderer
         // https://svgwg.org/svg2-draft/render.html#ObjectAndGroupOpacityProperties
         // https://drafts.csswg.org/css-color/#transparency
 
+        // null
+        if ($value == null) {
+            return 1;
+        }
+
         // real numbers
         if (is_numeric($value)) {
             return (float) $value;

--- a/src/Rasterization/Transform/TransformParser.php
+++ b/src/Rasterization/Transform/TransformParser.php
@@ -18,6 +18,9 @@ final class TransformParser
     public static function parseTransformString($input, Transform $applyTo = null)
     {
         $transform = isset($applyTo) ? $applyTo : Transform::identity();
+        if ($input == null) {
+            return $transform;
+        }
 
         // https://www.w3.org/TR/css-transforms-1/#svg-syntax
 


### PR DESCRIPTION
With php8.1 comes deprecation-warnings.

`Passing null to parameter of type string is deprecated`

I have fixed these who appeared on my website.