### PR TITLE
Declare `null` return typehints on SVG::getWidth/getHeight

### DIFF
--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -43,7 +43,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     }
 
     /**
-     * @return string The declared width of this document.
+     * @return string|null The declared width of this document or null.
      */
     public function getWidth()
     {
@@ -63,7 +63,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     }
 
     /**
-     * @return string The declared height of this document.
+     * @return string|null The declared height of this document or null.
      */
     public function getHeight()
     {


### PR DESCRIPTION
This will help a little bit for static analysis tools