### PR TITLE
fix: Add shim for trim() that accepts null

### DIFF
--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -3,6 +3,7 @@
 namespace SVG\Nodes;
 
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Shims\Str;
 
 /**
  * Represents a single element inside an SVG image (in other words, an XML tag).
@@ -108,7 +109,7 @@ abstract class SVGNode
      */
     public function setStyle($name, $value)
     {
-        $value = trim($value);
+        $value = Str::trim($value);
         if (strlen($value) === 0) {
             unset($this->styles[$name]);
             return $this;
@@ -249,8 +250,8 @@ abstract class SVGNode
      */
     public function getIdAndClassPattern()
     {
-        $id = $this->getAttribute('id') != null ? trim($this->getAttribute('id')) : '';
-        $class = $this->getAttribute('class') != null  ? trim($this->getAttribute('class')) : '';
+        $id = $this->getAttribute('id') != null ? Str::trim($this->getAttribute('id')) : '';
+        $class = $this->getAttribute('class') != null  ? Str::trim($this->getAttribute('class')) : '';
 
         $pattern = '';
         if ($id !== '') {
@@ -277,7 +278,7 @@ abstract class SVGNode
         if ($this->getAttribute('viewBox') == null) {
             return null;
         }
-        $attr = trim($this->getAttribute('viewBox'));
+        $attr = Str::trim($this->getAttribute('viewBox'));
         $result = preg_split('/[\s,]+/', $attr);
         if (count($result) !== 4) {
             return null;

--- a/src/Nodes/SVGNodeContainer.php
+++ b/src/Nodes/SVGNodeContainer.php
@@ -5,6 +5,7 @@ namespace SVG\Nodes;
 use SVG\Nodes\Structures\SVGStyle;
 use SVG\Rasterization\SVGRasterizer;
 use SVG\Rasterization\Transform\TransformParser;
+use SVG\Shims\Str;
 use SVG\Utilities\SVGStyleParser;
 
 /**
@@ -251,7 +252,7 @@ abstract class SVGNodeContainer extends SVGNode
     public function getElementsByClassName($className, array &$result = array())
     {
         if (!is_array($className)) {
-            $className = preg_split('/\s+/', trim($className));
+            $className = preg_split('/\s+/', Str::trim($className));
         }
         // shortcut if empty
         if (empty($className) || $className[0] === '') {

--- a/src/Nodes/Shapes/SVGPolygonalShape.php
+++ b/src/Nodes/Shapes/SVGPolygonalShape.php
@@ -3,6 +3,7 @@
 namespace SVG\Nodes\Shapes;
 
 use SVG\Nodes\SVGNodeContainer;
+use SVG\Shims\Str;
 
 /**
  * This is the base class for polygons and polylines.
@@ -38,7 +39,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
         }
 
         $pointsAttribute = $this->getAttribute('points') ?: '';
-        $this->setAttribute('points', trim($pointsAttribute . ' ' . $a . ',' . $b));
+        $this->setAttribute('points', Str::trim($pointsAttribute . ' ' . $a . ',' . $b));
 
         return $this;
     }
@@ -118,7 +119,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
 
     private static function splitCoordinates($pointsString)
     {
-        return preg_split('/[\s,]+/', trim($pointsString));
+        return preg_split('/[\s,]+/', Str::trim($pointsString));
     }
 
     private static function joinCoordinates(array $coordinatesArray)

--- a/src/Rasterization/Path/PathParser.php
+++ b/src/Rasterization/Path/PathParser.php
@@ -2,6 +2,8 @@
 
 namespace SVG\Rasterization\Path;
 
+use SVG\Shims\Str;
+
 /**
  * This class can convert SVG path description strings into arrays of distinct
  * commands + their arguments.
@@ -65,7 +67,7 @@ class PathParser
      */
     private function splitArguments($str)
     {
-        $str = trim($str);
+        $str = Str::trim($str);
 
         $args = array();
         if ($str !== '') {

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -5,6 +5,7 @@ namespace SVG\Rasterization\Renderers;
 use SVG\Nodes\SVGNode;
 use SVG\Rasterization\SVGRasterizer;
 use SVG\Rasterization\Transform\Transform;
+use SVG\Shims\Str;
 use SVG\Utilities\Colors\Color;
 use SVG\Utilities\Units\Length;
 
@@ -127,7 +128,7 @@ abstract class MultiPassRenderer extends Renderer
     private static function getPaintOrder(SVGNode $context)
     {
         $paintOrder = $context->getComputedStyle('paint-order');
-        $paintOrder = preg_replace('#\s{2,}#', ' ', trim($paintOrder));
+        $paintOrder = preg_replace('#\s{2,}#', ' ', Str::trim($paintOrder));
 
         $defaultOrder = array('fill', 'stroke', 'markers');
 

--- a/src/Shims/Str.php
+++ b/src/Shims/Str.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SVG\Shims;
+
+class Str
+{
+    /**
+     * Strip whitespace (or other characters) from the beginning and end of a string.
+     *
+     * This is a shim for PHP's native trim() function.
+     * As calling trim() on null is deprecated as of PHP 8.1 this method reproduces the behaviour of <8.1.
+     *
+     * @param string $string
+     * @param string $characters
+     *
+     * @return string
+     */
+    public static function trim($string, $characters = " \n\r\t\v\x00")
+    {
+        if (is_null($string)) {
+            $string = (string)$string;
+        }
+
+        return trim($string, $characters);
+    }
+}

--- a/src/Shims/Str.php
+++ b/src/Shims/Str.php
@@ -17,7 +17,7 @@ class Str
      */
     public static function trim($string, $characters = " \n\r\t\v\x00")
     {
-        if (is_null($string)) {
+        if ($string === null) {
             $string = (string)$string;
         }
 

--- a/src/Utilities/Colors/Color.php
+++ b/src/Utilities/Colors/Color.php
@@ -2,6 +2,7 @@
 
 namespace SVG\Utilities\Colors;
 
+use SVG\Shims\Str;
 use SVG\Utilities\Units\Angle;
 
 final class Color
@@ -104,7 +105,7 @@ final class Color
      */
     private static function parseRGBAComponents($str)
     {
-        $params = preg_split('/(\s*[\/,]\s*)|(\s+)/', trim($str));
+        $params = preg_split('/(\s*[\/,]\s*)|(\s+)/', Str::trim($str));
         if (count($params) !== 3 && count($params) !== 4) {
             return array(null, null, null, null);
         }
@@ -162,7 +163,7 @@ final class Color
     private static function parseHSLAComponents($str)
     {
         // split on delimiters
-        $params = preg_split('/(\s*[\/,]\s*)|(\s+)/', trim($str));
+        $params = preg_split('/(\s*[\/,]\s*)|(\s+)/', Str::trim($str));
         if (count($params) !== 3 && count($params) !== 4) {
             return null;
         }

--- a/src/Utilities/SVGStyleParser.php
+++ b/src/Utilities/SVGStyleParser.php
@@ -2,6 +2,8 @@
 
 namespace SVG\Utilities;
 
+use SVG\Shims\Str;
+
 /**
  * This is a utility class used to parse CSS rules.
  */
@@ -24,7 +26,7 @@ abstract class SVGStyleParser
         $declarations = preg_split('/\s*;\s*/', $string);
 
         foreach ($declarations as $declaration) {
-            $declaration = trim($declaration);
+            $declaration = Str::trim($declaration);
             if ($declaration === '') {
                 continue;
             }
@@ -51,13 +53,13 @@ abstract class SVGStyleParser
         preg_match_all('/(?ims)([a-z0-9\s\,\.\:#_\-@^*()\[\]\"\'=]+)\{([^\}]*)\}/', $css, $arr);
 
         foreach ($arr[0] as $i => $x) {
-            $selectors = explode(',', trim($arr[1][$i]));
+            $selectors = explode(',', Str::trim($arr[1][$i]));
             if (in_array($selectors[0], array('@font-face', '@keyframes', '@media'))) {
                 continue;
             }
-            $rules = self::parseStyles(trim($arr[2][$i]));
+            $rules = self::parseStyles(Str::trim($arr[2][$i]));
             foreach ($selectors as $selector) {
-                $result[trim($selector)] = $rules;
+                $result[Str::trim($selector)] = $rules;
             }
         }
 

--- a/src/Writing/SVGWriter.php
+++ b/src/Writing/SVGWriter.php
@@ -5,6 +5,7 @@ namespace SVG\Writing;
 use SVG\Nodes\SVGNode;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Nodes\CDataContainer;
+use SVG\Shims\Str;
 
 /**
  * This class is used for composing ("writing") XML strings from nodes.
@@ -70,7 +71,7 @@ class SVGWriter
             return;
         }
 
-        if (trim($textContent) !== '') {
+        if (Str::trim($textContent) !== '') {
             $this->outString .= '>' . $textContent . '</' . $node->getName() . '>';
             return;
         }

--- a/tests/Shims/StrTest.php
+++ b/tests/Shims/StrTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SVG\Shims;
+
+use PHPUnit\Framework\TestCase;
+
+class StrTest extends TestCase
+{
+    /** @dataProvider provideTrimsWithDefaultCharacters */
+    public function testTrimsWithDefaultCharacters($input, $expectedResult)
+    {
+        $result = Str::trim($input);
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /** @provides testTrimsWithDefaultCharacters */
+    public function provideTrimsWithDefaultCharacters()
+    {
+        return array(
+            "It trims null" => array(null, ""),
+            "It trims empty string" => array("", ""),
+            "It trims front" => array(" foo", "foo"),
+            "It trims end" => array("bar ", "bar"),
+            "It trims front and end" => array(" foobar ", 'foobar'),
+            "It doesn't touch the middle" => array(" foo baz ", 'foo baz'),
+            "It trims tabs" => array(" \t foo", 'foo'),
+            "It trims carriage returns" => array("bar \r", 'bar'),
+            "It trims NUL-byte" => array("foobar \0", 'foobar'),
+            "It trims vertical tab" => array("foobaz \v", 'foobaz'),
+        );
+    }
+
+    /** @dataProvider provideTrimsWithCustomCharacters */
+    public function testTrimsWithCustomCharacters($input, $expectedResult)
+    {
+        $result = Str::trim($input, "NeverGonnaGiveYouUp");
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /** @provides testTrimsWithCustomCharacters */
+    public function provideTrimsWithCustomCharacters()
+    {
+        return array(
+            "It trims null" => array(null, ''),
+            "It trims empty string" => array('', ''),
+            "It doesn't trim spaces (1)" => array(' FOO', ' FOO'),
+            "It doesn't trim spaces (2)" => array('bar ', 'bar '),
+            "It trims front" => array('NeverGonnaGiveYouUp Never gonna let you down!', ' Never gonna let you down!'),
+            "It doesn't touch the middle" => array('FOO N BAR', 'FOO N BAR')
+        );
+    }
+}


### PR DESCRIPTION
- Added \SVG\Shims\Str::trim() that accepts null as an argument as this is deprecated for PHPs native trim() as of PHP 8.1.
- Replaced all instances of trim() for the newly added shim.