### PR TITLE
fix: Use the coalescing operator `??`

### DIFF
--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -63,7 +63,7 @@ abstract class SVGNode
      */
     public function getValue()
     {
-        return isset($this->value) ? $this->value : '';
+        return $this->value ?? '';
     }
 
     /**
@@ -94,7 +94,7 @@ abstract class SVGNode
     public function getStyle($name)
     {
         // whitespace has been trimmed in the setter
-        return isset($this->styles[$name]) ? $this->styles[$name] : null;
+        return $this->styles[$name] ?? null;
     }
 
     /**
@@ -148,7 +148,7 @@ abstract class SVGNode
         // If no immediate style then get style from container/global style rules
         if ($style === null && isset($this->parent)) {
             $containerStyles = $this->parent->getContainerStyleForNode($this);
-            $style = isset($containerStyles[$name]) ? $containerStyles[$name] : null;
+            $style = $containerStyles[$name] ?? null;
         }
 
         // If still no style then get parent's style
@@ -171,7 +171,7 @@ abstract class SVGNode
      */
     public function getAttribute($name)
     {
-        return isset($this->attributes[$name]) ? $this->attributes[$name] : null;
+        return $this->attributes[$name] ?? null;
     }
 
     /**

--- a/src/Rasterization/Path/PolygonBuilder.php
+++ b/src/Rasterization/Path/PolygonBuilder.php
@@ -97,8 +97,8 @@ class PolygonBuilder
      */
     public function addPoint($x, $y)
     {
-        $x = isset($x) ? $x : $this->posX;
-        $y = isset($y) ? $y : $this->posY;
+        $x = $x ?? $this->posX;
+        $y = $y ?? $this->posY;
 
         $this->points[] = [$x, $y];
 

--- a/src/Rasterization/Renderers/PolygonRenderer.php
+++ b/src/Rasterization/Renderers/PolygonRenderer.php
@@ -26,7 +26,7 @@ class PolygonRenderer extends MultiPassRenderer
         }
 
         return [
-            'open'      => isset($options['open']) ? $options['open'] : false,
+            'open'      => $options['open'] ?? false,
             'points'    => $points,
             'fill-rule' => $options['fill-rule'],
         ];

--- a/src/Rasterization/Transform/TransformParser.php
+++ b/src/Rasterization/Transform/TransformParser.php
@@ -17,7 +17,7 @@ final class TransformParser
      */
     public static function parseTransformString($input, Transform $applyTo = null)
     {
-        $transform = isset($applyTo) ? $applyTo : Transform::identity();
+        $transform = $applyTo ?? Transform::identity();
         if ($input == null) {
             return $transform;
         }


### PR DESCRIPTION
The coalescing operator is available since PHP 7. Since we now have a minimum version requirement of 7.3 (see PR #182), we can simplify some code by using it.