### PR TITLE
chore: Remove TODO about PHP version 5.3 missing a parameter

### DIFF
--- a/src/Reading/SVGReader.php
+++ b/src/Reading/SVGReader.php
@@ -180,7 +180,6 @@ class SVGReader
         $node = NodeRegistry::create($tagName);
 
         // obtain array of namespaces that are declared directly on this node
-        // TODO find solution for PHP < 5.4 (where the 2nd parameter was introduced)
         $extraNamespaces = @$xml->getDocNamespaces(false, false);
         if (!empty($extraNamespaces)) {
             $namespaces = array_unique(array_merge($namespaces, array_keys($extraNamespaces)));

--- a/tests/Reading/SVGReaderTest.php
+++ b/tests/Reading/SVGReaderTest.php
@@ -264,11 +264,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('g {display:none;}', $doc->getChild(0)->getValue());
     }
 
-    // the following requirement is due to SimpleXMLElement::getDocNamespaces
-    // not accepting 2 arguments below 5.4
-    /**
-     * @requires PHP 5.4
-     */
     public function testChildKeepsNamespaces()
     {
         $code  = '<svg xmlns="http://www.w3.org/2000/svg">';
@@ -285,9 +280,6 @@ class SVGReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('<div xmlns="http://www.w3.org/1999/xhtml" xmlns:foo="bar">', '' . $result);
     }
 
-    /**
-     * @requires PHP 5.4
-     */
     public function testParsesChildNamespacedAttributes()
     {
         $code  = '<svg xmlns="http://www.w3.org/2000/svg">';


### PR DESCRIPTION
Fixes #109. We don't support PHP 5.3 anymore due to PR #182, so the TODO can safely be removed, along with the `@requires` on associated tests.