### PR TITLE
chore: update README, add newer PHP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/meyfa/php-svg/actions/workflows/php.yml/badge.svg)](https://github.com/meyfa/php-svg/actions/workflows/php.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8f73468601a653aff0e8/maintainability)](https://codeclimate.com/github/meyfa/php-svg/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/8f73468601a653aff0e8/test_coverage)](https://codeclimate.com/github/meyfa/php-svg/test_coverage)
+![Packagist PHP Version](https://img.shields.io/packagist/dependency-v/meyfa/php-svg/php?style=plastic)
 [![Packagist Downloads](https://img.shields.io/packagist/dt/meyfa/php-svg)](https://packagist.org/packages/meyfa/php-svg)
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Contributions are very welcome. [Find out how to contribute](#contributing).
 
 PHP-SVG is free of dependencies. All it needs is a PHP installation satisfying the following requirements:
 
-* PHP version 7.3 or newer. This library is tested against all versions up to PHP 8.
+* PHP version 7.3 or newer. This library is tested against all versions up to (and including) PHP 8.2.
 * If you wish to load SVG files, or strings containing SVG code, you need to have the
   ['simplexml' PHP extension](https://www.php.net/manual/en/book.simplexml.php).
 * If you wish to use the rasterization feature for converting SVGs to raster images (PNGs, JPEGs, ...), you need to


### PR DESCRIPTION
As discussed in #187 older versions were dropped and support for PHP 8.1 and 8.2 was added. Updated README to also mention newer versions.