### PR TITLE
feat: Add type declarations for SVGNode methods

### DIFF
--- a/src/Nodes/Embedded/SVGForeignObject.php
+++ b/src/Nodes/Embedded/SVGForeignObject.php
@@ -20,7 +20,7 @@ class SVGForeignObject extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Embedded/SVGImage.php
+++ b/src/Nodes/Embedded/SVGImage.php
@@ -18,12 +18,12 @@ class SVGImage extends SVGNodeContainer
 
     /**
      * @param string|null $href   The image path, URL or URI.
-     * @param string|null $x      The x coordinate of the upper left corner.
-     * @param string|null $y      The y coordinate of the upper left corner.
-     * @param string|null $width  The width.
-     * @param string|null $height The height.
+     * @param mixed $x      The x coordinate of the upper left corner.
+     * @param mixed $y      The y coordinate of the upper left corner.
+     * @param mixed $width  The width.
+     * @param mixed $height The height.
      */
-    public function __construct($href = null, $x = null, $y = null, $width = null, $height = null)
+    public function __construct(?string $href = null, $x = null, $y = null, $width = null, $height = null)
     {
         parent::__construct();
 
@@ -39,15 +39,21 @@ class SVGImage extends SVGNodeContainer
      *
      * @param string     $path
      * @param string     $mimeType
-     * @param float|null $x
-     * @param float|null $y
-     * @param float|null $width
-     * @param float|null $height
+     * @param mixed $x
+     * @param mixed $y
+     * @param mixed $width
+     * @param mixed $height
      *
      * @return self
      */
-    public static function fromFile($path, $mimeType, $x = null, $y = null, $width = null, $height = null)
-    {
+    public static function fromFile(
+        string $path,
+        string $mimeType,
+        $x = null,
+        $y = null,
+        $width = null,
+        $height = null
+    ): SVGImage {
         $imageContent = file_get_contents($path);
         if ($imageContent === false) {
             throw new RuntimeException('Image file "' . $path . '" could not be read.');
@@ -68,21 +74,21 @@ class SVGImage extends SVGNodeContainer
      *
      * @param string     $imageContent
      * @param string     $mimeType
-     * @param float|null $x
-     * @param float|null $y
-     * @param float|null $width
-     * @param float|null $height
+     * @param mixed $x
+     * @param mixed $y
+     * @param mixed $width
+     * @param mixed $height
      *
      * @return self
      */
     public static function fromString(
-        $imageContent,
-        $mimeType,
+        string $imageContent,
+        string $mimeType,
         $x = null,
         $y = null,
         $width = null,
         $height = null
-    ) {
+    ): SVGImage {
         return new self(
             sprintf(
                 'data:%s;base64,%s',
@@ -99,7 +105,7 @@ class SVGImage extends SVGNodeContainer
     /**
      * @return string|null The image path, URL or URI.
      */
-    public function getHref()
+    public function getHref(): ?string
     {
         return $this->getAttribute('xlink:href') ?: $this->getAttribute('href');
     }
@@ -107,11 +113,11 @@ class SVGImage extends SVGNodeContainer
     /**
      * Sets this image's path, URL or URI.
      *
-     * @param string $href The new image hyperreference.
+     * @param string|null $href The new image hyper reference.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setHref($href)
+    public function setHref(?string $href): SVGImage
     {
         return $this->setAttribute('xlink:href', $href);
     }
@@ -119,7 +125,7 @@ class SVGImage extends SVGNodeContainer
     /**
      * @return string|null The x coordinate of the upper left corner.
      */
-    public function getX()
+    public function getX(): ?string
     {
         return $this->getAttribute('x');
     }
@@ -127,11 +133,11 @@ class SVGImage extends SVGNodeContainer
     /**
      * Sets the x coordinate of the upper left corner.
      *
-     * @param string $x The new coordinate.
+     * @param mixed $x The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setX($x)
+    public function setX($x): SVGImage
     {
         return $this->setAttribute('x', $x);
     }
@@ -139,7 +145,7 @@ class SVGImage extends SVGNodeContainer
     /**
      * @return string|null The y coordinate of the upper left corner.
      */
-    public function getY()
+    public function getY(): ?string
     {
         return $this->getAttribute('y');
     }
@@ -147,11 +153,11 @@ class SVGImage extends SVGNodeContainer
     /**
      * Sets the y coordinate of the upper left corner.
      *
-     * @param string $y The new coordinate.
+     * @param mixed $y The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setY($y)
+    public function setY($y): SVGImage
     {
         return $this->setAttribute('y', $y);
     }
@@ -159,17 +165,17 @@ class SVGImage extends SVGNodeContainer
     /**
      * @return string|null The width.
      */
-    public function getWidth()
+    public function getWidth(): ?string
     {
         return $this->getAttribute('width');
     }
 
     /**
-     * @param string $width The new width.
+     * @param mixed $width The new width.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setWidth($width)
+    public function setWidth($width): SVGImage
     {
         return $this->setAttribute('width', $width);
     }
@@ -177,17 +183,17 @@ class SVGImage extends SVGNodeContainer
     /**
      * @return string|null The height.
      */
-    public function getHeight()
+    public function getHeight(): ?string
     {
         return $this->getAttribute('height');
     }
 
     /**
-     * @param string $height The new height.
+     * @param mixed $height The new height.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setHeight($height)
+    public function setHeight($height): SVGImage
     {
         return $this->setAttribute('height', $height);
     }
@@ -195,7 +201,7 @@ class SVGImage extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;

--- a/src/Nodes/Filters/SVGFEBlend.php
+++ b/src/Nodes/Filters/SVGFEBlend.php
@@ -20,7 +20,7 @@ class SVGFEBlend extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEColorMatrix.php
+++ b/src/Nodes/Filters/SVGFEColorMatrix.php
@@ -20,7 +20,7 @@ class SVGFEColorMatrix extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEComponentTransfer.php
+++ b/src/Nodes/Filters/SVGFEComponentTransfer.php
@@ -20,7 +20,7 @@ class SVGFEComponentTransfer extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEComposite.php
+++ b/src/Nodes/Filters/SVGFEComposite.php
@@ -20,7 +20,7 @@ class SVGFEComposite extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEConvolveMatrix.php
+++ b/src/Nodes/Filters/SVGFEConvolveMatrix.php
@@ -20,7 +20,7 @@ class SVGFEConvolveMatrix extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEDiffuseLighting.php
+++ b/src/Nodes/Filters/SVGFEDiffuseLighting.php
@@ -20,7 +20,7 @@ class SVGFEDiffuseLighting extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEDisplacementMap.php
+++ b/src/Nodes/Filters/SVGFEDisplacementMap.php
@@ -20,7 +20,7 @@ class SVGFEDisplacementMap extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEDistantLight.php
+++ b/src/Nodes/Filters/SVGFEDistantLight.php
@@ -20,7 +20,7 @@ class SVGFEDistantLight extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEDropShadow.php
+++ b/src/Nodes/Filters/SVGFEDropShadow.php
@@ -20,7 +20,7 @@ class SVGFEDropShadow extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEFlood.php
+++ b/src/Nodes/Filters/SVGFEFlood.php
@@ -20,7 +20,7 @@ class SVGFEFlood extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEFuncA.php
+++ b/src/Nodes/Filters/SVGFEFuncA.php
@@ -20,7 +20,7 @@ class SVGFEFuncA extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEFuncB.php
+++ b/src/Nodes/Filters/SVGFEFuncB.php
@@ -20,7 +20,7 @@ class SVGFEFuncB extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEFuncG.php
+++ b/src/Nodes/Filters/SVGFEFuncG.php
@@ -20,7 +20,7 @@ class SVGFEFuncG extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEFuncR.php
+++ b/src/Nodes/Filters/SVGFEFuncR.php
@@ -20,7 +20,7 @@ class SVGFEFuncR extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEGaussianBlur.php
+++ b/src/Nodes/Filters/SVGFEGaussianBlur.php
@@ -20,7 +20,7 @@ class SVGFEGaussianBlur extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEImage.php
+++ b/src/Nodes/Filters/SVGFEImage.php
@@ -20,7 +20,7 @@ class SVGFEImage extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEMerge.php
+++ b/src/Nodes/Filters/SVGFEMerge.php
@@ -20,7 +20,7 @@ class SVGFEMerge extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEMergeNode.php
+++ b/src/Nodes/Filters/SVGFEMergeNode.php
@@ -20,7 +20,7 @@ class SVGFEMergeNode extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEMorphology.php
+++ b/src/Nodes/Filters/SVGFEMorphology.php
@@ -20,7 +20,7 @@ class SVGFEMorphology extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEOffset.php
+++ b/src/Nodes/Filters/SVGFEOffset.php
@@ -20,7 +20,7 @@ class SVGFEOffset extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFEPointLight.php
+++ b/src/Nodes/Filters/SVGFEPointLight.php
@@ -20,7 +20,7 @@ class SVGFEPointLight extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFESpecularLighting.php
+++ b/src/Nodes/Filters/SVGFESpecularLighting.php
@@ -20,7 +20,7 @@ class SVGFESpecularLighting extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFESpotLight.php
+++ b/src/Nodes/Filters/SVGFESpotLight.php
@@ -20,7 +20,7 @@ class SVGFESpotLight extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFETile.php
+++ b/src/Nodes/Filters/SVGFETile.php
@@ -20,7 +20,7 @@ class SVGFETile extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFETurbulence.php
+++ b/src/Nodes/Filters/SVGFETurbulence.php
@@ -20,7 +20,7 @@ class SVGFETurbulence extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Filters/SVGFilter.php
+++ b/src/Nodes/Filters/SVGFilter.php
@@ -20,7 +20,7 @@ class SVGFilter extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGAnimate.php
+++ b/src/Nodes/Presentation/SVGAnimate.php
@@ -20,7 +20,7 @@ class SVGAnimate extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGAnimateMotion.php
+++ b/src/Nodes/Presentation/SVGAnimateMotion.php
@@ -20,7 +20,7 @@ class SVGAnimateMotion extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGAnimateTransform.php
+++ b/src/Nodes/Presentation/SVGAnimateTransform.php
@@ -20,7 +20,7 @@ class SVGAnimateTransform extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGLinearGradient.php
+++ b/src/Nodes/Presentation/SVGLinearGradient.php
@@ -20,7 +20,7 @@ class SVGLinearGradient extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGMPath.php
+++ b/src/Nodes/Presentation/SVGMPath.php
@@ -20,7 +20,7 @@ class SVGMPath extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGRadialGradient.php
+++ b/src/Nodes/Presentation/SVGRadialGradient.php
@@ -20,7 +20,7 @@ class SVGRadialGradient extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGSet.php
+++ b/src/Nodes/Presentation/SVGSet.php
@@ -20,7 +20,7 @@ class SVGSet extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGStop.php
+++ b/src/Nodes/Presentation/SVGStop.php
@@ -20,7 +20,7 @@ class SVGStop extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Presentation/SVGView.php
+++ b/src/Nodes/Presentation/SVGView.php
@@ -20,7 +20,7 @@ class SVGView extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/SVGGenericNodeType.php
+++ b/src/Nodes/SVGGenericNodeType.php
@@ -12,7 +12,7 @@ class SVGGenericNodeType extends SVGNodeContainer
 {
     private $tagName;
 
-    public function __construct($tagName)
+    public function __construct(string $tagName)
     {
         parent::__construct();
         $this->tagName = $tagName;
@@ -21,7 +21,7 @@ class SVGGenericNodeType extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->tagName;
     }
@@ -29,7 +29,7 @@ class SVGGenericNodeType extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // do nothing
     }

--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -33,7 +33,7 @@ abstract class SVGNode
     /**
      * @return string This node's tag name (e.g. 'rect' or 'g').
      */
-    public function getName()
+    public function getName(): string
     {
         return static::TAG_NAME;
     }
@@ -41,7 +41,7 @@ abstract class SVGNode
     /**
      * @return SVGNodeContainer|null This node's parent node, if not root.
      */
-    public function getParent()
+    public function getParent(): ?SVGNodeContainer
     {
         return $this->parent;
     }
@@ -51,7 +51,7 @@ abstract class SVGNode
      *
      * @param string[] $namespaces A mapping from namespace id => URI.
      */
-    public function setNamespaces(array $namespaces)
+    public function setNamespaces(array $namespaces): void
     {
         $this->namespaces = $namespaces;
     }
@@ -61,7 +61,7 @@ abstract class SVGNode
      *
      * @return string The node's value
      */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value ?? '';
     }
@@ -69,11 +69,11 @@ abstract class SVGNode
     /**
      * Defines the value on this node.
      *
-     * @param string $value The new node's value.
+     * @param string|null $value The new node's value.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setValue($value)
+    public function setValue(?string $value): SVGNode
     {
         if (!isset($value)) {
             unset($this->value);
@@ -91,9 +91,9 @@ abstract class SVGNode
      *
      * @return string|null The style value if specified on this node, else null.
      */
-    public function getStyle($name)
+    public function getStyle(string $name): ?string
     {
-        // whitespace has been trimmed in the setter
+        // Note: whitespace has been trimmed in the setter
         return $this->styles[$name] ?? null;
     }
 
@@ -102,14 +102,14 @@ abstract class SVGNode
      * unset the property. Since whitespace surrounding style values is meaningless, it will be trimmed such that later
      * retrieval of the style property or computed style property will yield the value with no surrounding whitespace.
      *
-     * @param string      $name  The name of the style to set.
-     * @param string|null $value The new style value.
+     * @param string     $name  The name of the style to set.
+     * @param mixed|null $value The new style value.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setStyle($name, $value)
+    public function setStyle(string $name, $value): SVGNode
     {
-        $value = Str::trim($value);
+        $value = Str::trim((string) $value);
         if (strlen($value) === 0) {
             unset($this->styles[$name]);
             return $this;
@@ -125,7 +125,7 @@ abstract class SVGNode
      *
      * @return $this This node instance, for call chaining.
      */
-    public function removeStyle($name)
+    public function removeStyle(string $name): SVGNode
     {
         unset($this->styles[$name]);
         return $this;
@@ -141,7 +141,7 @@ abstract class SVGNode
      *
      * @return string|null The style value if specified anywhere, else null.
      */
-    public function getComputedStyle($name)
+    public function getComputedStyle(string $name): ?string
     {
         $style = $this->getStyle($name);
 
@@ -169,7 +169,7 @@ abstract class SVGNode
      *
      * @return string|null The attribute's value, or null.
      */
-    public function getAttribute($name)
+    public function getAttribute(string $name): ?string
     {
         return $this->attributes[$name] ?? null;
     }
@@ -178,12 +178,12 @@ abstract class SVGNode
      * Defines an attribute on this node. A value of null will unset the
      * attribute. Note that the empty string is perfectly valid.
      *
-     * @param string      $name  The name of the attribute to set.
-     * @param string|null $value The new attribute value.
+     * @param string     $name  The name of the attribute to set.
+     * @param mixed|null $value The new attribute value.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setAttribute($name, $value)
+    public function setAttribute(string $name, $value): SVGNode
     {
         if (!isset($value)) {
             unset($this->attributes[$name]);
@@ -200,7 +200,7 @@ abstract class SVGNode
      *
      * @return $this This node instance, for call chaining.
      */
-    public function removeAttribute($name)
+    public function removeAttribute(string $name): SVGNode
     {
         unset($this->attributes[$name]);
         return $this;
@@ -214,7 +214,7 @@ abstract class SVGNode
      *
      * @return string[] The attribute mapping to include in generated XML.
      */
-    public function getSerializableAttributes()
+    public function getSerializableAttributes(): array
     {
         return $this->attributes;
     }
@@ -227,7 +227,7 @@ abstract class SVGNode
      *
      * @return string[] The style mapping to include in generated XML.
      */
-    public function getSerializableStyles()
+    public function getSerializableStyles(): array
     {
         return $this->styles;
     }
@@ -237,7 +237,7 @@ abstract class SVGNode
      *
      * @return string[] The namespace mapping to include in generated XML.
      */
-    public function getSerializableNamespaces()
+    public function getSerializableNamespaces(): array
     {
         return $this->namespaces;
     }
@@ -248,7 +248,7 @@ abstract class SVGNode
      *
      * @return string|null The generated pattern.
      */
-    public function getIdAndClassPattern()
+    public function getIdAndClassPattern(): ?string
     {
         $id = $this->getAttribute('id') != null ? Str::trim($this->getAttribute('id')) : '';
         $class = $this->getAttribute('class') != null  ? Str::trim($this->getAttribute('class')) : '';
@@ -273,7 +273,7 @@ abstract class SVGNode
      *
      * @return float[]|null The viewbox array.
      */
-    public function getViewBox()
+    public function getViewBox(): ?array
     {
         if ($this->getAttribute('viewBox') == null) {
             return null;
@@ -294,7 +294,7 @@ abstract class SVGNode
      *
      * @return void
      */
-    abstract public function rasterize(SVGRasterizer $rasterizer);
+    abstract public function rasterize(SVGRasterizer $rasterizer): void;
 
     /**
      * Returns all descendants of this node (excluding this node) having the
@@ -310,7 +310,7 @@ abstract class SVGNode
      *
      * @SuppressWarnings("unused")
      */
-    public function getElementsByTagName($tagName, array &$result = [])
+    public function getElementsByTagName(string $tagName, array &$result = []): array
     {
         return $result;
     }
@@ -336,7 +336,7 @@ abstract class SVGNode
      *
      * @SuppressWarnings("unused")
      */
-    public function getElementsByClassName($className, array &$result = [])
+    public function getElementsByClassName($className, array &$result = []): array
     {
         return $result;
     }

--- a/src/Nodes/SVGNodeContainer.php
+++ b/src/Nodes/SVGNodeContainer.php
@@ -34,12 +34,12 @@ abstract class SVGNodeContainer extends SVGNode
      * at the end of the child list.
      * Does nothing if the node already exists in this container.
      *
-     * @param SVGNode $node  The node to add to this container's children.
-     * @param int     $index The position to insert at (optional).
+     * @param SVGNode  $node  The node to add to this container's children.
+     * @param int|null $index The position to insert at (optional).
      *
      * @return $this This node instance, for call chaining.
      */
-    public function addChild(SVGNode $node, $index = null)
+    public function addChild(SVGNode $node, int $index = null): SVGNodeContainer
     {
         if ($node === $this || $node->parent === $this) {
             return $this;
@@ -71,7 +71,7 @@ abstract class SVGNodeContainer extends SVGNode
      *
      * @return $this This node instance, for call chaining.
      */
-    public function removeChild($child)
+    public function removeChild($child): SVGNodeContainer
     {
         $index = $this->resolveChildIndex($child);
         if ($index === false) {
@@ -94,7 +94,7 @@ abstract class SVGNodeContainer extends SVGNode
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setChild($child, SVGNode $node)
+    public function setChild($child, SVGNode $node): SVGNodeContainer
     {
         $index = $this->resolveChildIndex($child);
         if ($index === false) {
@@ -129,15 +129,16 @@ abstract class SVGNodeContainer extends SVGNode
     /**
      * @return int The amount of children in this container.
      */
-    public function countChildren()
+    public function countChildren(): int
     {
         return count($this->children);
     }
 
     /**
+     * @param int $index The index of the child to get.
      * @return SVGNode The child node at the given index.
      */
-    public function getChild($index)
+    public function getChild(int $index): SVGNode
     {
         return $this->children[$index];
     }
@@ -149,7 +150,7 @@ abstract class SVGNodeContainer extends SVGNode
      *
      * @return $this This node instance, for call chaining.
      */
-    public function addContainerStyle(SVGStyle $styleNode)
+    public function addContainerStyle(SVGStyle $styleNode): SVGNodeContainer
     {
         $newStyles = SVGStyleParser::parseCss($styleNode->getValue());
         $this->containerStyles = array_merge($this->containerStyles, $newStyles);
@@ -160,7 +161,7 @@ abstract class SVGNodeContainer extends SVGNode
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;
@@ -185,7 +186,7 @@ abstract class SVGNodeContainer extends SVGNode
      *
      * @return string[] The style rules to be applied.
      */
-    public function getContainerStyleForNode(SVGNode $node)
+    public function getContainerStyleForNode(SVGNode $node): array
     {
         $pattern = $node->getIdAndClassPattern();
 
@@ -195,11 +196,11 @@ abstract class SVGNodeContainer extends SVGNode
     /**
      * Returns style rules for the given node id + class pattern.
      *
-     * @param string $pattern The node's pattern.
+     * @param string|null $pattern The node's pattern.
      *
      * @return string[] The style rules to be applied.
      */
-    public function getContainerStyleByPattern($pattern)
+    public function getContainerStyleByPattern(?string $pattern): array
     {
         if ($pattern === null) {
             return [];
@@ -226,7 +227,7 @@ abstract class SVGNodeContainer extends SVGNode
      *
      * @return string[] The matches array
      */
-    private function pregGrepStyle($pattern)
+    private function pregGrepStyle(string $pattern): array
     {
         return preg_grep($pattern, array_keys($this->containerStyles));
     }
@@ -234,7 +235,7 @@ abstract class SVGNodeContainer extends SVGNode
     /**
      * @inheritdoc
      */
-    public function getElementsByTagName($tagName, array &$result = [])
+    public function getElementsByTagName(string $tagName, array &$result = []): array
     {
         foreach ($this->children as $child) {
             if ($tagName === '*' || $child->getName() === $tagName) {
@@ -249,7 +250,7 @@ abstract class SVGNodeContainer extends SVGNode
     /**
      * @inheritdoc
      */
-    public function getElementsByClassName($className, array &$result = [])
+    public function getElementsByClassName($className, array &$result = []): array
     {
         if (!is_array($className)) {
             $className = preg_split('/\s+/', Str::trim($className));

--- a/src/Nodes/Shapes/SVGCircle.php
+++ b/src/Nodes/Shapes/SVGCircle.php
@@ -16,9 +16,9 @@ class SVGCircle extends SVGNodeContainer
     const TAG_NAME = 'circle';
 
     /**
-     * @param string|null $cx The center's x coordinate.
-     * @param string|null $cy The center's y coordinate.
-     * @param string|null $r  The radius.
+     * @param mixed $cx The center's x coordinate.
+     * @param mixed $cy The center's y coordinate.
+     * @param mixed $r  The radius.
      */
     public function __construct($cx = null, $cy = null, $r = null)
     {
@@ -32,7 +32,7 @@ class SVGCircle extends SVGNodeContainer
     /**
      * @return string|null The center's x coordinate.
      */
-    public function getCenterX()
+    public function getCenterX(): ?string
     {
         return $this->getAttribute('cx');
     }
@@ -40,11 +40,11 @@ class SVGCircle extends SVGNodeContainer
     /**
      * Sets the center's x coordinate.
      *
-     * @param string $cx The new coordinate.
+     * @param mixed $cx The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setCenterX($cx)
+    public function setCenterX($cx): SVGCircle
     {
         return $this->setAttribute('cx', $cx);
     }
@@ -52,7 +52,7 @@ class SVGCircle extends SVGNodeContainer
     /**
      * @return string|null The center's y coordinate.
      */
-    public function getCenterY()
+    public function getCenterY(): ?string
     {
         return $this->getAttribute('cy');
     }
@@ -60,11 +60,11 @@ class SVGCircle extends SVGNodeContainer
     /**
      * Sets the center's y coordinate.
      *
-     * @param string $cy The new coordinate.
+     * @param mixed $cy The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setCenterY($cy)
+    public function setCenterY($cy): SVGCircle
     {
         return $this->setAttribute('cy', $cy);
     }
@@ -72,7 +72,7 @@ class SVGCircle extends SVGNodeContainer
     /**
      * @return string|null The radius.
      */
-    public function getRadius()
+    public function getRadius(): ?string
     {
         return $this->getAttribute('r');
     }
@@ -80,11 +80,11 @@ class SVGCircle extends SVGNodeContainer
     /**
      * Sets the radius.
      *
-     * @param string $r The new radius.
+     * @param mixed $r The new radius.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setRadius($r)
+    public function setRadius($r): SVGCircle
     {
         return $this->setAttribute('r', $r);
     }
@@ -92,7 +92,7 @@ class SVGCircle extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;

--- a/src/Nodes/Shapes/SVGEllipse.php
+++ b/src/Nodes/Shapes/SVGEllipse.php
@@ -16,10 +16,10 @@ class SVGEllipse extends SVGNodeContainer
     const TAG_NAME = 'ellipse';
 
     /**
-     * @param string|null $cx The center's x coordinate.
-     * @param string|null $cy The center's y coordinate.
-     * @param string|null $rx The radius along the x-axis.
-     * @param string|null $ry The radius along the y-axis.
+     * @param mixed $cx The center's x coordinate.
+     * @param mixed $cy The center's y coordinate.
+     * @param mixed $rx The radius along the x-axis.
+     * @param mixed $ry The radius along the y-axis.
      */
     public function __construct($cx = null, $cy = null, $rx = null, $ry = null)
     {
@@ -34,7 +34,7 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * @return string|null The center's x coordinate.
      */
-    public function getCenterX()
+    public function getCenterX(): ?string
     {
         return $this->getAttribute('cx');
     }
@@ -42,11 +42,11 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * Sets the center's x coordinate.
      *
-     * @param string $cx The new coordinate.
+     * @param mixed $cx The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setCenterX($cx)
+    public function setCenterX($cx): SVGEllipse
     {
         return $this->setAttribute('cx', $cx);
     }
@@ -54,7 +54,7 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * @return string|null The center's y coordinate.
      */
-    public function getCenterY()
+    public function getCenterY(): ?string
     {
         return $this->getAttribute('cy');
     }
@@ -62,11 +62,11 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * Sets the center's y coordinate.
      *
-     * @param string $cy The new coordinate.
+     * @param mixed $cy The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setCenterY($cy)
+    public function setCenterY($cy): SVGEllipse
     {
         return $this->setAttribute('cy', $cy);
     }
@@ -74,7 +74,7 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * @return string|null The radius along the x-axis.
      */
-    public function getRadiusX()
+    public function getRadiusX(): ?string
     {
         return $this->getAttribute('rx');
     }
@@ -82,11 +82,11 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * Sets the radius along the x-axis.
      *
-     * @param string $rx The new radius.
+     * @param mixed $rx The new radius.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setRadiusX($rx)
+    public function setRadiusX($rx): SVGEllipse
     {
         return $this->setAttribute('rx', $rx);
     }
@@ -94,7 +94,7 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * @return string|null The radius along the y-axis.
      */
-    public function getRadiusY()
+    public function getRadiusY(): ?string
     {
         return $this->getAttribute('ry');
     }
@@ -102,11 +102,11 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * Sets the radius along the y-axis.
      *
-     * @param string $ry The new radius.
+     * @param mixed $ry The new radius.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setRadiusY($ry)
+    public function setRadiusY($ry): SVGEllipse
     {
         return $this->setAttribute('ry', $ry);
     }
@@ -114,7 +114,7 @@ class SVGEllipse extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;

--- a/src/Nodes/Shapes/SVGLine.php
+++ b/src/Nodes/Shapes/SVGLine.php
@@ -16,10 +16,10 @@ class SVGLine extends SVGNodeContainer
     const TAG_NAME = 'line';
 
     /**
-     * @param string|null $x1 The first point's x coordinate.
-     * @param string|null $y1 The first point's y coordinate.
-     * @param string|null $x2 The second point's x coordinate.
-     * @param string|null $y2 The second point's y coordinate.
+     * @param mixed $x1 The first point's x coordinate.
+     * @param mixed $y1 The first point's y coordinate.
+     * @param mixed $x2 The second point's x coordinate.
+     * @param mixed $y2 The second point's y coordinate.
      */
     public function __construct($x1 = null, $y1 = null, $x2 = null, $y2 = null)
     {
@@ -34,7 +34,7 @@ class SVGLine extends SVGNodeContainer
     /**
      * @return string|null The first point's x coordinate.
      */
-    public function getX1()
+    public function getX1(): ?string
     {
         return $this->getAttribute('x1');
     }
@@ -42,11 +42,11 @@ class SVGLine extends SVGNodeContainer
     /**
      * Sets the first point's x coordinate.
      *
-     * @param string $x1 The new coordinate.
+     * @param mixed $x1 The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setX1($x1)
+    public function setX1($x1): SVGLine
     {
         return $this->setAttribute('x1', $x1);
     }
@@ -54,7 +54,7 @@ class SVGLine extends SVGNodeContainer
     /**
      * @return string|null The first point's y coordinate.
      */
-    public function getY1()
+    public function getY1(): ?string
     {
         return $this->getAttribute('y1');
     }
@@ -62,11 +62,11 @@ class SVGLine extends SVGNodeContainer
     /**
      * Sets the first point's y coordinate.
      *
-     * @param string $y1 The new coordinate.
+     * @param mixed $y1 The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setY1($y1)
+    public function setY1($y1): SVGLine
     {
         return $this->setAttribute('y1', $y1);
     }
@@ -74,7 +74,7 @@ class SVGLine extends SVGNodeContainer
     /**
      * @return string|null The second point's x coordinate.
      */
-    public function getX2()
+    public function getX2(): ?string
     {
         return $this->getAttribute('x2');
     }
@@ -82,11 +82,11 @@ class SVGLine extends SVGNodeContainer
     /**
      * Sets the second point's x coordinate.
      *
-     * @param string $x2 The new coordinate.
+     * @param mixed $x2 The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setX2($x2)
+    public function setX2($x2): SVGLine
     {
         return $this->setAttribute('x2', $x2);
     }
@@ -94,7 +94,7 @@ class SVGLine extends SVGNodeContainer
     /**
      * @return string|null The second point's y coordinate.
      */
-    public function getY2()
+    public function getY2(): ?string
     {
         return $this->getAttribute('y2');
     }
@@ -102,11 +102,11 @@ class SVGLine extends SVGNodeContainer
     /**
      * Sets the second point's y coordinate.
      *
-     * @param string $y2 The new coordinate.
+     * @param mixed $y2 The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setY2($y2)
+    public function setY2($y2): SVGLine
     {
         return $this->setAttribute('y2', $y2);
     }
@@ -114,7 +114,7 @@ class SVGLine extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -19,7 +19,7 @@ class SVGPath extends SVGNodeContainer
     /**
      * @param string|null $d The path description.
      */
-    public function __construct($d = null)
+    public function __construct(string $d = null)
     {
         parent::__construct();
 
@@ -29,7 +29,7 @@ class SVGPath extends SVGNodeContainer
     /**
      * @return string|null The path description string.
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->getAttribute('d');
     }
@@ -37,11 +37,11 @@ class SVGPath extends SVGNodeContainer
     /**
      * Sets the path description string.
      *
-     * @param string $d The new description.
+     * @param string|null $d The new description.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setDescription($d)
+    public function setDescription(?string $d): SVGPath
     {
         return $this->setAttribute('d', $d);
     }
@@ -49,7 +49,7 @@ class SVGPath extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;
@@ -77,7 +77,7 @@ class SVGPath extends SVGNodeContainer
         $rasterizer->popTransform();
     }
 
-    private static function getPathParser()
+    private static function getPathParser(): PathParser
     {
         if (!isset(self::$pathParser)) {
             self::$pathParser = new PathParser();

--- a/src/Nodes/Shapes/SVGPolygon.php
+++ b/src/Nodes/Shapes/SVGPolygon.php
@@ -16,7 +16,7 @@ class SVGPolygon extends SVGPolygonalShape
     /**
      * @param array[] $points Array of points (float 2-tuples).
      */
-    public function __construct($points = [])
+    public function __construct(array $points = [])
     {
         parent::__construct($points);
     }
@@ -24,7 +24,7 @@ class SVGPolygon extends SVGPolygonalShape
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;

--- a/src/Nodes/Shapes/SVGPolygonalShape.php
+++ b/src/Nodes/Shapes/SVGPolygonalShape.php
@@ -32,7 +32,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
      *
      * @return $this This node instance, for call chaining.
      */
-    public function addPoint($a, $b = null)
+    public function addPoint($a, $b = null): SVGPolygonalShape
     {
         if (is_array($a)) {
             list($a, $b) = $a;
@@ -51,7 +51,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
      *
      * @return $this This node instance, for call chaining.
      */
-    public function removePoint($index)
+    public function removePoint(int $index): SVGPolygonalShape
     {
         $coords = self::splitCoordinates($this->getAttribute('points') ?: '');
         array_splice($coords, $index * 2, 2);
@@ -63,7 +63,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
     /**
      * @return int The number of points in this shape.
      */
-    public function countPoints()
+    public function countPoints(): int
     {
         $pointsAttribute = $this->getAttribute('points');
         if (isset($pointsAttribute)) {
@@ -76,7 +76,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
     /**
      * @return array[] All points in this shape (array of float 2-tuples).
      */
-    public function getPoints()
+    public function getPoints(): array
     {
         $pointsAttribute = $this->getAttribute('points');
         if (isset($pointsAttribute)) {
@@ -90,7 +90,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
      *
      * @return float[] The point at the given index (0 => x, 1 => y).
      */
-    public function getPoint($index)
+    public function getPoint(int $index): array
     {
         $coords = self::splitCoordinates($this->getAttribute('points') ?: '');
         return [
@@ -107,7 +107,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setPoint($index, array $point)
+    public function setPoint(int $index, array $point): SVGPolygonalShape
     {
         $coords = self::splitCoordinates($this->getAttribute('points') ?: '');
         $coords[$index * 2] = $point[0];
@@ -117,12 +117,12 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
         return $this;
     }
 
-    private static function splitCoordinates($pointsString)
+    private static function splitCoordinates(?string $pointsString): array
     {
         return preg_split('/[\s,]+/', Str::trim($pointsString));
     }
 
-    private static function joinCoordinates(array $coordinatesArray)
+    private static function joinCoordinates(array $coordinatesArray): string
     {
         $pointsString = '';
         for ($i = 0, $n = count($coordinatesArray); $i < $n; ++$i) {
@@ -135,7 +135,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
         return $pointsString;
     }
 
-    private static function splitPoints($pointsString)
+    private static function splitPoints(?string $pointsString): array
     {
         $pointsArray = [];
         $coords = self::splitCoordinates($pointsString);
@@ -148,7 +148,7 @@ abstract class SVGPolygonalShape extends SVGNodeContainer
         return $pointsArray;
     }
 
-    private static function joinPoints(array $pointsArray)
+    private static function joinPoints(array $pointsArray): string
     {
         $pointsString = '';
         foreach ($pointsArray as $point) {

--- a/src/Nodes/Shapes/SVGPolyline.php
+++ b/src/Nodes/Shapes/SVGPolyline.php
@@ -24,7 +24,7 @@ class SVGPolyline extends SVGPolygonalShape
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;

--- a/src/Nodes/Shapes/SVGRect.php
+++ b/src/Nodes/Shapes/SVGRect.php
@@ -16,10 +16,10 @@ class SVGRect extends SVGNodeContainer
     const TAG_NAME = 'rect';
 
     /**
-     * @param string|null $x      The x coordinate of the upper left corner.
-     * @param string|null $y      The y coordinate of the upper left corner.
-     * @param string|null $width  The width.
-     * @param string|null $height The height.
+     * @param mixed $x      The x coordinate of the upper left corner.
+     * @param mixed $y      The y coordinate of the upper left corner.
+     * @param mixed $width  The width.
+     * @param mixed $height The height.
      */
     public function __construct($x = null, $y = null, $width = null, $height = null)
     {
@@ -34,7 +34,7 @@ class SVGRect extends SVGNodeContainer
     /**
      * @return string|null The x coordinate of the upper left corner.
      */
-    public function getX()
+    public function getX(): ?string
     {
         return $this->getAttribute('x');
     }
@@ -42,11 +42,11 @@ class SVGRect extends SVGNodeContainer
     /**
      * Sets the x coordinate of the upper left corner.
      *
-     * @param string $x The new coordinate.
+     * @param mixed $x The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setX($x)
+    public function setX($x): SVGRect
     {
         return $this->setAttribute('x', $x);
     }
@@ -54,7 +54,7 @@ class SVGRect extends SVGNodeContainer
     /**
      * @return string|null The y coordinate of the upper left corner.
      */
-    public function getY()
+    public function getY(): ?string
     {
         return $this->getAttribute('y');
     }
@@ -62,11 +62,11 @@ class SVGRect extends SVGNodeContainer
     /**
      * Sets the y coordinate of the upper left corner.
      *
-     * @param string $y The new coordinate.
+     * @param mixed $y The new coordinate.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setY($y)
+    public function setY($y): SVGRect
     {
         return $this->setAttribute('y', $y);
     }
@@ -74,17 +74,17 @@ class SVGRect extends SVGNodeContainer
     /**
      * @return string|null The width.
      */
-    public function getWidth()
+    public function getWidth(): ?string
     {
         return $this->getAttribute('width');
     }
 
     /**
-     * @param string $width The new width.
+     * @param mixed $width The new width.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setWidth($width)
+    public function setWidth($width): SVGRect
     {
         return $this->setAttribute('width', $width);
     }
@@ -92,17 +92,17 @@ class SVGRect extends SVGNodeContainer
     /**
      * @return string|null The height.
      */
-    public function getHeight()
+    public function getHeight(): ?string
     {
         return $this->getAttribute('height');
     }
 
     /**
-     * @param string $height The new height.
+     * @param mixed $height The new height.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setHeight($height)
+    public function setHeight($height): SVGRect
     {
         return $this->setAttribute('height', $height);
     }
@@ -110,7 +110,7 @@ class SVGRect extends SVGNodeContainer
     /**
      * @return string|null The x radius of the corners.
      */
-    public function getRX()
+    public function getRX(): ?string
     {
         return $this->getAttribute('rx');
     }
@@ -118,11 +118,11 @@ class SVGRect extends SVGNodeContainer
     /**
      * Sets the x radius of the corners.
      *
-     * @param string $rx The new radius.
+     * @param mixed $rx The new radius.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setRX($rx)
+    public function setRX($rx): SVGRect
     {
         return $this->setAttribute('rx', $rx);
     }
@@ -130,7 +130,7 @@ class SVGRect extends SVGNodeContainer
     /**
      * @return string|null The y radius of the corners.
      */
-    public function getRY()
+    public function getRY(): ?string
     {
         return $this->getAttribute('ry');
     }
@@ -138,11 +138,11 @@ class SVGRect extends SVGNodeContainer
     /**
      * Sets the y radius of the corners.
      *
-     * @param string $ry The new radius.
+     * @param mixed $ry The new radius.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setRY($ry)
+    public function setRY($ry): SVGRect
     {
         return $this->setAttribute('ry', $ry);
     }
@@ -150,7 +150,7 @@ class SVGRect extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->getComputedStyle('display') === 'none') {
             return;

--- a/src/Nodes/Structures/SVGClipPath.php
+++ b/src/Nodes/Structures/SVGClipPath.php
@@ -12,7 +12,7 @@ class SVGClipPath extends SVGNodeContainer
 {
     const TAG_NAME = 'clipPath';
 
-    public function __construct($id = null)
+    public function __construct(string $id = null)
     {
         parent::__construct();
 
@@ -22,7 +22,7 @@ class SVGClipPath extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // TODO How do we rasterize this? The clipPath in and of itself wont get rasterized, but usages of it will be!
     }

--- a/src/Nodes/Structures/SVGDefs.php
+++ b/src/Nodes/Structures/SVGDefs.php
@@ -20,7 +20,7 @@ class SVGDefs extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -2,6 +2,7 @@
 
 namespace SVG\Nodes\Structures;
 
+use SVG\Nodes\SVGNode;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
 use SVG\Utilities\Units\Length;
@@ -14,7 +15,7 @@ class SVGDocumentFragment extends SVGNodeContainer
 {
     const TAG_NAME = 'svg';
 
-    /** @var mixed[] $initialStyles A map of style keys to their defaults. */
+    /** @var array $initialStyles A map of style keys to their defaults. */
     private static $initialStyles = [
         'fill'          => '#000000',
         'stroke'        => 'none',
@@ -37,7 +38,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * @return bool Whether this is the root document.
      */
-    public function isRoot()
+    public function isRoot(): bool
     {
         return $this->getParent() === null;
     }
@@ -45,7 +46,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * @return string|null The declared width of this document or null.
      */
-    public function getWidth()
+    public function getWidth(): ?string
     {
         return $this->getAttribute('width');
     }
@@ -53,11 +54,11 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * Declares a new width for this document.
      *
-     * @param string $width The new width.
+     * @param mixed $width The new width.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setWidth($width)
+    public function setWidth($width): SVGDocumentFragment
     {
         return $this->setAttribute('width', $width);
     }
@@ -65,7 +66,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * @return string|null The declared height of this document or null.
      */
-    public function getHeight()
+    public function getHeight(): ?string
     {
         return $this->getAttribute('height');
     }
@@ -73,11 +74,11 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * Declares a new height for this document.
      *
-     * @param string $height The new height.
+     * @param mixed $height The new height.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setHeight($height)
+    public function setHeight($height): SVGDocumentFragment
     {
         return $this->setAttribute('height', $height);
     }
@@ -85,7 +86,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function getComputedStyle($name)
+    public function getComputedStyle(string $name): ?string
     {
         // return either explicit declarations ...
         $style = parent::getComputedStyle($name);
@@ -100,7 +101,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         if ($this->isRoot()) {
             parent::rasterize($rasterizer);
@@ -137,7 +138,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function getSerializableAttributes()
+    public function getSerializableAttributes(): array
     {
         $attrs = parent::getSerializableAttributes();
 
@@ -154,7 +155,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function getSerializableNamespaces()
+    public function getSerializableNamespaces(): array
     {
         if ($this->isRoot()) {
             return parent::getSerializableNamespaces() + [
@@ -171,9 +172,9 @@ class SVGDocumentFragment extends SVGNodeContainer
      *
      * @param string $id The id to search for.
      *
-     * @return \SVG\Nodes\SVGNode|null The node with the given id if it exists.
+     * @return SVGNode|null The node with the given id if it exists.
      */
-    public function getElementById($id)
+    public function getElementById(string $id): ?SVGNode
     {
         // start with document
         $stack = [$this];

--- a/src/Nodes/Structures/SVGMarker.php
+++ b/src/Nodes/Structures/SVGMarker.php
@@ -20,7 +20,7 @@ class SVGMarker extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Structures/SVGMask.php
+++ b/src/Nodes/Structures/SVGMask.php
@@ -20,7 +20,7 @@ class SVGMask extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Structures/SVGMetadata.php
+++ b/src/Nodes/Structures/SVGMetadata.php
@@ -20,7 +20,7 @@ class SVGMetadata extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Structures/SVGPattern.php
+++ b/src/Nodes/Structures/SVGPattern.php
@@ -20,7 +20,7 @@ class SVGPattern extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Structures/SVGScript.php
+++ b/src/Nodes/Structures/SVGScript.php
@@ -16,7 +16,7 @@ class SVGScript extends SVGNodeContainer implements CDataContainer
     /**
      * @param string $content The script content.
      */
-    public function __construct($content = '')
+    public function __construct(string $content = '')
     {
         parent::__construct();
 
@@ -26,7 +26,7 @@ class SVGScript extends SVGNodeContainer implements CDataContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
     }
 }

--- a/src/Nodes/Structures/SVGStyle.php
+++ b/src/Nodes/Structures/SVGStyle.php
@@ -18,7 +18,7 @@ class SVGStyle extends SVGNodeContainer implements CDataContainer
      * @param string $css   The CSS data rules.
      * @param string $type  The style type attribute.
      */
-    public function __construct($css = '', $type = 'text/css')
+    public function __construct(string $css = '', string $type = 'text/css')
     {
         parent::__construct();
 
@@ -27,19 +27,19 @@ class SVGStyle extends SVGNodeContainer implements CDataContainer
     }
 
     /**
-     * @return string The type attribute.
+     * @return string|null The type attribute.
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->getAttribute('type');
     }
 
     /**
-     * @param $type string The type attribute.
+     * @param $type string|null The type attribute.
      *
      * @return $this This node instance, for call chaining.
      */
-    public function setType($type)
+    public function setType(?string $type): SVGStyle
     {
         return $this->setAttribute('type', $type);
     }
@@ -47,7 +47,7 @@ class SVGStyle extends SVGNodeContainer implements CDataContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
     }
 }

--- a/src/Nodes/Structures/SVGSwitch.php
+++ b/src/Nodes/Structures/SVGSwitch.php
@@ -20,7 +20,7 @@ class SVGSwitch extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Structures/SVGSymbol.php
+++ b/src/Nodes/Structures/SVGSymbol.php
@@ -20,7 +20,7 @@ class SVGSymbol extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Structures/SVGUse.php
+++ b/src/Nodes/Structures/SVGUse.php
@@ -20,7 +20,7 @@ class SVGUse extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Texts/SVGDesc.php
+++ b/src/Nodes/Texts/SVGDesc.php
@@ -20,7 +20,7 @@ class SVGDesc extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Texts/SVGTSpan.php
+++ b/src/Nodes/Texts/SVGTSpan.php
@@ -20,7 +20,7 @@ class SVGTSpan extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Texts/SVGText.php
+++ b/src/Nodes/Texts/SVGText.php
@@ -27,7 +27,7 @@ class SVGText extends SVGNodeContainer
 {
     const TAG_NAME = 'text';
 
-    public function __construct($text = '', $x = 0, $y = 0)
+    public function __construct(string $text = '', $x = 0, $y = 0)
     {
         parent::__construct();
         $this->setValue($text);
@@ -42,7 +42,7 @@ class SVGText extends SVGNodeContainer
      * @param string $fontFamily The value for the CSS font-family property.
      * @return $this
      */
-    public function setFontFamily(string $fontFamily)
+    public function setFontFamily(string $fontFamily): SVGText
     {
         $this->setStyle('font-family', $fontFamily);
         return $this;
@@ -51,10 +51,10 @@ class SVGText extends SVGNodeContainer
     /**
      * Set the CSS font-size property.
      *
-     * @param $fontSize string The value for the CSS font-size property.
+     * @param $fontSize mixed The value for the CSS font-size property.
      * @return $this
      */
-    public function setFontSize($fontSize)
+    public function setFontSize($fontSize): SVGText
     {
         $this->setStyle('font-size', $fontSize);
         return $this;
@@ -63,7 +63,7 @@ class SVGText extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function getComputedStyle($name)
+    public function getComputedStyle(string $name): ?string
     {
         // force stroke before fill
         if ($name === 'paint-order') {
@@ -77,7 +77,7 @@ class SVGText extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
 

--- a/src/Nodes/Texts/SVGTextPath.php
+++ b/src/Nodes/Texts/SVGTextPath.php
@@ -20,7 +20,7 @@ class SVGTextPath extends SVGNodeContainer
     /**
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // Nothing to rasterize.
     }

--- a/src/Nodes/Texts/SVGTitle.php
+++ b/src/Nodes/Texts/SVGTitle.php
@@ -12,7 +12,7 @@ class SVGTitle extends SVGNodeContainer
 {
     const TAG_NAME = 'title';
 
-    public function __construct($text = '')
+    public function __construct(string $text = '')
     {
         parent::__construct();
         $this->setValue($text);
@@ -23,7 +23,7 @@ class SVGTitle extends SVGNodeContainer
      *
      * @inheritdoc
      */
-    public function rasterize(SVGRasterizer $rasterizer)
+    public function rasterize(SVGRasterizer $rasterizer): void
     {
         // nothing to rasterize
     }

--- a/src/Shims/Str.php
+++ b/src/Shims/Str.php
@@ -10,12 +10,12 @@ class Str
      * This is a shim for PHP's native trim() function.
      * As calling trim() on null is deprecated as of PHP 8.1 this method reproduces the behaviour of <8.1.
      *
-     * @param string $string
-     * @param string $characters
+     * @param string|null $string
+     * @param string      $characters
      *
      * @return string
      */
-    public static function trim($string, $characters = " \n\r\t\v\x00")
+    public static function trim(?string $string, string $characters = " \n\r\t\v\x00"): string
     {
         if ($string === null) {
             $string = (string)$string;

--- a/tests/Nodes/SVGNodeTest.php
+++ b/tests/Nodes/SVGNodeTest.php
@@ -11,7 +11,7 @@ class SVGNodeSubclass extends SVGNode
     /**
      * @inheritdoc
      */
-    public function rasterize(\SVG\Rasterization\SVGRasterizer $rasterizer)
+    public function rasterize(\SVG\Rasterization\SVGRasterizer $rasterizer): void
     {
     }
 }

--- a/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
+++ b/tests/Nodes/Shapes/SVGPolygonalShapeTest.php
@@ -16,7 +16,7 @@ class SVGPolygonalShapeSubclass extends SVGPolygonalShape
         parent::__construct($points);
     }
 
-    public function rasterize(\SVG\Rasterization\SVGRasterizer $rasterizer)
+    public function rasterize(\SVG\Rasterization\SVGRasterizer $rasterizer): void
     {
     }
 }

--- a/tests/Rasterization/Renderers/ImageRendererTest.php
+++ b/tests/Rasterization/Renderers/ImageRendererTest.php
@@ -12,7 +12,7 @@ class SVGNodeClass extends SVGNode
     /**
      * @inheritdoc
      */
-    public function rasterize(\SVG\Rasterization\SVGRasterizer $rasterizer)
+    public function rasterize(\SVG\Rasterization\SVGRasterizer $rasterizer): void
     {
     }
 }


### PR DESCRIPTION
This patch adds type declarations for all methods of SVGNode and of its subclasses. Some parameters of attribute setters were intentionally not restricted (i.e., they still allow `mixed`) so that it's still possible to pass in numeric values.