### PR TITLE
fix: Allow renderer short-circuit if unable to render anything

### DIFF
--- a/src/Rasterization/Renderers/EllipseRenderer.php
+++ b/src/Rasterization/Renderers/EllipseRenderer.php
@@ -19,7 +19,7 @@ class EllipseRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): array
+    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): ?array
     {
         $cx = $options['cx'];
         $cy = $options['cy'];

--- a/src/Rasterization/Renderers/LineRenderer.php
+++ b/src/Rasterization/Renderers/LineRenderer.php
@@ -19,7 +19,7 @@ class LineRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): array
+    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): ?array
     {
         $x1 = $options['x1'];
         $y1 = $options['y1'];

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -25,6 +25,9 @@ abstract class MultiPassRenderer extends Renderer
         $transform = $rasterizer->getCurrentTransform();
 
         $params = $this->prepareRenderParams($options, $transform, $rasterizer->getFontRegistry());
+        if (!isset($params)) {
+            return;
+        }
 
         $paintOrder = self::getPaintOrder($context);
         foreach ($paintOrder as $paint) {
@@ -75,19 +78,19 @@ abstract class MultiPassRenderer extends Renderer
     }
 
     /**
-     * Converts the options array into a new parameters array that the render
-     * methods can make more sense of.
+     * Converts the options array into a new parameters array that the render methods can make more sense of.
      *
-     * Specifically, the intention is to allow subclasses to outsource
-     * coordinate translation, approximation of curves and the like to this
-     * method rather than dealing with it in the render methods. This shall
-     * encourage single passes over the input data (for performance reasons).
+     * Specifically, the intention is to allow subclasses to outsource coordinate translation, approximation of curves
+     * and the like to this method rather than dealing with it in the render methods. This shall encourage single passes
+     * over the input data (for performance reasons).
+     *
+     * If this method determines that rendering isn't possible (e.g. because the shape is empty), it shall return null.
      *
      * @param array             $options      The associative array of raw options.
      * @param Transform         $transform    The coordinate transform to apply, to go from user to output coordinates.
      * @param FontRegistry|null $fontRegistry The font registry to use for text rendering.
      *
-     * @return array The new associative array of computed render parameters.
+     * @return array|null The new associative array of computed render parameters, if there is something to render.
      */
     abstract protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry);
 

--- a/src/Rasterization/Renderers/PathRenderer.php
+++ b/src/Rasterization/Renderers/PathRenderer.php
@@ -21,7 +21,7 @@ class PathRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): array
+    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): ?array
     {
         $approximator = new PathApproximator($transform);
         $approximator->approximate($options['commands']);

--- a/src/Rasterization/Renderers/PolygonRenderer.php
+++ b/src/Rasterization/Renderers/PolygonRenderer.php
@@ -19,7 +19,7 @@ class PolygonRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): array
+    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): ?array
     {
         $points = [];
         foreach ($options['points'] as $point) {

--- a/src/Rasterization/Renderers/RectRenderer.php
+++ b/src/Rasterization/Renderers/RectRenderer.php
@@ -21,14 +21,14 @@ class RectRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): array
+    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): ?array
     {
         $w = $options['width'];
         $h = $options['height'];
         $transform->resize($w, $h);
 
         if ($w <= 0 || $h <= 0) {
-            return ['empty' => true];
+            return null;
         }
 
         $x1 = $options['x'];
@@ -54,7 +54,6 @@ class RectRenderer extends MultiPassRenderer
         }
 
         return [
-            'empty' => false,
             'x1' => $x1,
             'y1' => $y1,
             'x2' => $x1 + $w - 1,
@@ -69,10 +68,6 @@ class RectRenderer extends MultiPassRenderer
      */
     protected function renderFill($image, $params, int $color): void
     {
-        if ($params['empty']) {
-            return;
-        }
-
         if ($params['rx'] != 0 || $params['ry'] != 0) {
             $this->renderFillRounded($image, $params, $color);
             return;
@@ -133,10 +128,6 @@ class RectRenderer extends MultiPassRenderer
      */
     protected function renderStroke($image, $params, int $color, float $strokeWidth): void
     {
-        if ($params['empty']) {
-            return;
-        }
-
         imagesetthickness($image, round($strokeWidth));
 
         if ($params['rx'] != 0 || $params['ry'] != 0) {

--- a/src/Rasterization/Renderers/TextRenderer.php
+++ b/src/Rasterization/Renderers/TextRenderer.php
@@ -23,7 +23,7 @@ class TextRenderer extends MultiPassRenderer
     /**
      * @inheritdoc
      */
-    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): array
+    protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): ?array
     {
         // this assumes there is no rotation or skew, but that's fine, we can't deal with that anyway
         $size1 = $options['fontSize'];
@@ -39,6 +39,10 @@ class TextRenderer extends MultiPassRenderer
             if ($matchingFont !== null) {
                 $fontPath = $matchingFont->getPath();
             }
+        }
+
+        if (!isset($fontPath)) {
+            return null;
         }
 
         // text-anchor

--- a/tests/Rasterization/Renderers/TextRendererTest.php
+++ b/tests/Rasterization/Renderers/TextRendererTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SVG\Rasterization\Renderers;
+
+use AssertGD\GDSimilarityConstraint;
+use SVG\Rasterization\SVGRasterizer;
+
+/**
+ * @requires extension gd
+ * @covers \SVG\Rasterization\Renderers\TextRenderer
+ *
+ * @SuppressWarnings(PHPMD)
+ */
+class TextRendererTest extends \PHPUnit\Framework\TestCase
+{
+    public function testShouldNotFailWithoutRegisteredFont()
+    {
+        $obj = new TextRenderer();
+
+        $context = $this->getMockForAbstractClass('\SVG\Nodes\SVGNode');
+
+        $rasterizer = new SVGRasterizer('40px', '80px', null, 4, 8);
+        $obj->render($rasterizer, [
+            'x'          => 10,
+            'y'          => 10,
+            'fontFamily' => 'Roboto',
+            'fontWeight' => 'normal',
+            'fontStyle'  => 'normal',
+            'fontSize'   => 16,
+            'anchor'     => 'middle',
+            'text'       => 'foo',
+        ], $context);
+        $img = $rasterizer->finish();
+
+        $this->assertThat($img, new GDSimilarityConstraint('./tests/images/empty-4x8.png'));
+    }
+}


### PR DESCRIPTION
The text renderer would previously throw in some circumstances if no font was available. With this patch, its `prepareRenderParams()` method can return `null` in these cases, aborting the render for that text element without causing a crash.

This also simplifies RectRenderer, which doesn't need an "empty" state anymore.