### PR TITLE
RectRenderer: For undefined x and y attributes use 0 as default value

### DIFF
--- a/src/Rasterization/Renderers/RectRenderer.php
+++ b/src/Rasterization/Renderers/RectRenderer.php
@@ -31,8 +31,8 @@ class RectRenderer extends MultiPassRenderer
             return null;
         }
 
-        $x1 = $options['x'];
-        $y1 = $options['y'];
+        $x1 = $options['x'] ?? 0;
+        $y1 = $options['y'] ?? 0;
         $transform->map($x1, $y1);
 
         // Corner radii may at most be (width-1)/2 pixels long.


### PR DESCRIPTION
Resolves https://github.com/meyfa/php-svg/issues/203