### PR TITLE
chore: Add typed properties /  refactor: Use null coalescing assignment where possbile.

### DIFF
--- a/src/Fonts/FontRegistry.php
+++ b/src/Fonts/FontRegistry.php
@@ -4,7 +4,7 @@ namespace SVG\Fonts;
 
 class FontRegistry
 {
-    private $fontFiles = [];
+    private array $fontFiles = [];
 
     public function addFont(string $filePath): void
     {

--- a/src/Fonts/TrueTypeFontFile.php
+++ b/src/Fonts/TrueTypeFontFile.php
@@ -24,9 +24,9 @@ class TrueTypeFontFile extends FontFile
     private const PLATFORM_ID_MACINTOSH = 1;
     private const PLATFORM_ID_WINDOWS = 3;
 
-    private $family;
-    private $subfamily;
-    private $weightClass;
+    private string $family;
+    private string $subfamily;
+    private ?int $weightClass;
 
     public function __construct(string $path, string $family, string $subfamily, ?int $weightClass)
     {

--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -12,15 +12,15 @@ use SVG\Shims\Str;
 abstract class SVGNode
 {
     /** @var SVGNodeContainer $parent The parent node. */
-    protected $parent;
+    protected SVGNodeContainer $parent;
     /** @var string[] $namespaces A map of custom namespaces to their URIs. */
     private $namespaces;
     /** @var string[] $attributes This node's set of attributes. */
-    protected $attributes;
+    protected array $attributes;
     /** @var string[] $styles This node's set of explicit style declarations. */
-    protected $styles;
+    protected array $styles;
     /** @var string $value This node's value */
-    protected $value;
+    protected string $value;
 
     public function __construct()
     {

--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -16,7 +16,7 @@ class SVGDocumentFragment extends SVGNodeContainer
     const TAG_NAME = 'svg';
 
     /** @var array $initialStyles A map of style keys to their defaults. */
-    private static $initialStyles = [
+    private static array $initialStyles = [
         'fill'          => '#000000',
         'stroke'        => 'none',
         'stroke-width'  => '1',

--- a/src/Rasterization/Path/PathApproximator.php
+++ b/src/Rasterization/Path/PathApproximator.php
@@ -19,7 +19,7 @@ class PathApproximator
     /**
      * @var string[] $commands A map of command ids to approximation functions.
      */
-    private static $commands = [
+    private static array $commands = [
         'M' => 'moveTo',                    'm' => 'moveTo',
         'L' => 'lineTo',                    'l' => 'lineTo',
         'H' => 'lineToHorizontal',          'h' => 'lineToHorizontal',
@@ -35,7 +35,7 @@ class PathApproximator
     /**
      * @var BezierApproximator $bezier The singleton bezier approximator.
      */
-    private static $bezier;
+    private static BezierApproximator $bezier;
     /**
      * @var ArcApproximator $arc The singleton arc approximator.
      */
@@ -44,17 +44,17 @@ class PathApproximator
     /**
      * @var Transform $transform The transform to use.
      */
-    private $transform;
+    private Transform $transform;
 
     /**
      * @var float[][][] $subpaths The approximation result up until now.
      */
-    private $subpaths = [];
+    private array $subpaths = [];
 
     /**
      * @var PolygonBuilder|null $builder The current subpath builder.
      */
-    private $builder;
+    private ?PolygonBuilder $builder;
 
     // the start of the current subpath, in path coordinates
     private $firstX;
@@ -71,11 +71,11 @@ class PathApproximator
     /**
      * @var float[] $cubicOld Second control point of last C or S command.
      */
-    private $cubicOld;
+    private array $cubicOld;
     /**
      * @var float[] $quadraticOld Control point of last Q or T command.
      */
-    private $quadraticOld;
+    private array $quadraticOld;
 
     /**
      * Construct a new, empty approximator.

--- a/src/Rasterization/Path/PathParser.php
+++ b/src/Rasterization/Path/PathParser.php
@@ -13,7 +13,7 @@ class PathParser
     /**
      * @var int[] $commandLengths A map of command ids to their argument counts.
      */
-    private static $commandLengths = [
+    private static array $commandLengths = [
         'M' => 2,   'm' => 2,   // MoveTo
         'L' => 2,   'l' => 2,   // LineTo
         'H' => 1,   'h' => 1,   // LineToHorizontal

--- a/src/Rasterization/Path/PolygonBuilder.php
+++ b/src/Rasterization/Path/PolygonBuilder.php
@@ -13,16 +13,16 @@ class PolygonBuilder
     /**
      * @var array[] $points The polygon being built (array of float 2-tuples).
      */
-    private $points = [];
+    private array $points = [];
 
     /**
      * @var float $posX The current x position.
      */
-    private $posX;
+    private float $posX;
     /**
      * @var float $posY The current y position.
      */
-    private $posY;
+    private float $posY;
 
     /**
      * @param float $posX The starting x position.

--- a/src/Rasterization/Renderers/PathRendererEdge.php
+++ b/src/Rasterization/Renderers/PathRendererEdge.php
@@ -20,17 +20,17 @@ class PathRendererEdge
     /**
      * @var int The vertical winding direction of this edge, 1 if top to bottom, -1 if bottom to top.
      */
-    public $direction;
+    public int $direction;
 
     /**
      * @var float Delta x over delta y of this edge, or 0 if the edge is fully horizontal (dy === 0).
      */
-    public $inverseSlope;
+    public float $inverseSlope;
 
     /**
      * @var float Initially, the x coordinate belonging to the maxY value, but slides upwards during scanning.
      */
-    public $x;
+    public float $x;
 
     /**
      * Construct a new edge object from the two end points. The order of points is important here,

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -28,31 +28,31 @@ class SVGRasterizer
     /** @var Renderers\Renderer[] $renderers Map of shapes to renderers. */
     private static $renderers;
 
-    private $fontRegistry;
+    private ?FontRegistry $fontRegistry;
 
     /**
      * @var float[] The document's viewBox (x, y, w, h).
      */
-    private $viewBox;
+    private ?array $viewBox;
 
     /**
      * @var int $width  The output image width, in pixels.
      */
-    private $width;
+    private int $width;
     /**
      * @var int $height The output image height, in pixels.
      */
-    private $height;
+    private int $height;
 
     /** @var resource $outImage The output image as a GD resource. */
     private $outImage;
 
     // precomputed properties for getter methods, used often during render
-    private $docWidth;
-    private $docHeight;
+    private ?float $docWidth;
+    private ?float $docHeight;
     private $diagonalScale;
 
-    private $transformStack;
+    private array $transformStack;
 
     /**
      * @param string|null $docWidth   The original SVG document width, as a string.

--- a/src/Rasterization/Transform/Transform.php
+++ b/src/Rasterization/Transform/Transform.php
@@ -19,7 +19,7 @@ namespace SVG\Rasterization\Transform;
  */
 class Transform
 {
-    private $matrix;
+    private array $matrix;
 
     /**
      * Create a transform from the given matrix. The entries [a, b, c, d, e, f] represent the following matrix:

--- a/src/Reading/AttributeRegistry.php
+++ b/src/Reading/AttributeRegistry.php
@@ -12,7 +12,7 @@ class AttributeRegistry
      * @var string[] @styleAttributes Attributes to be interpreted as styles.
      * List comes from https://www.w3.org/TR/SVG/styling.html.
      */
-    private static $styleAttributes = [
+    private static array $styleAttributes = [
         // DEFINED IN BOTH CSS2 AND SVG
         // font properties
         'font', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch',
@@ -49,7 +49,7 @@ class AttributeRegistry
      * @var string[] $styleConverters Map of style attributes to class names
      * for SVG attribute to CSS property conversion.
      */
-    private static $styleConverters = [
+    private static array $styleConverters = [
         'font-size'         => 'SVG\Reading\LengthAttributeConverter',
         'letter-spacing'    => 'SVG\Reading\LengthAttributeConverter',
         'word-spacing'      => 'SVG\Reading\LengthAttributeConverter',

--- a/src/Reading/LengthAttributeConverter.php
+++ b/src/Reading/LengthAttributeConverter.php
@@ -12,7 +12,7 @@ namespace SVG\Reading;
  */
 class LengthAttributeConverter implements AttributeConverter
 {
-    private static $instance;
+    private static LengthAttributeConverter $instance;
 
     /**
      * @codeCoverageIgnore

--- a/src/Reading/NodeRegistry.php
+++ b/src/Reading/NodeRegistry.php
@@ -14,7 +14,7 @@ class NodeRegistry
     /**
     * @var string[] $nodeTypes Map of tag names to fully-qualified class names.
     */
-    private static $nodeTypes = [
+    private static array $nodeTypes = [
         'foreignObject'         => 'SVG\Nodes\Embedded\SVGForeignObject',
         'image'                 => 'SVG\Nodes\Embedded\SVGImage',
 

--- a/src/SVG.php
+++ b/src/SVG.php
@@ -15,12 +15,12 @@ use SVG\Writing\SVGWriter;
 class SVG
 {
     /** @var SVGReader $reader The singleton reader used by this class. */
-    private static $reader;
+    private static SVGReader $reader;
 
-    private static $fontRegistry;
+    private static FontRegistry $fontRegistry;
 
     /** @var SVGDocumentFragment $document This image's root `svg` node/tag. */
-    private $document;
+    private SVGDocumentFragment $document;
 
     /**
      * @param mixed $width    The image's width (any CSS length).

--- a/src/Utilities/Colors/ColorLookup.php
+++ b/src/Utilities/Colors/ColorLookup.php
@@ -27,7 +27,7 @@ final class ColorLookup
      * @var array[] $values A map of color names to their RGBA arrays.
      * @see https://www.w3.org/TR/SVG11/types.html#ColorKeywords For the source.
      */
-    private static $values = [
+    private static array $values = [
         'transparent'           => [  0,   0,   0,   0],
         'aliceblue'             => [240, 248, 255, 255],
         'antiquewhite'          => [250, 235, 215, 255],

--- a/src/Writing/SVGWriter.php
+++ b/src/Writing/SVGWriter.php
@@ -14,7 +14,7 @@ use SVG\Shims\Str;
 class SVGWriter
 {
     /** @var string $outString The XML output string being written */
-    private $outString = '';
+    private string $outString = '';
 
     public function __construct(bool $isStandalone = true)
     {

--- a/tests/Nodes/Shapes/SVGPathTest.php
+++ b/tests/Nodes/Shapes/SVGPathTest.php
@@ -12,8 +12,8 @@ use SVG\Nodes\Shapes\SVGPath;
  */
 class SVGPathTest extends \PHPUnit\Framework\TestCase
 {
-    private static $sampleDescription = 'M100,100 h20 Z M200,200 h20';
-    private static $sampleCommands = [
+    private static string $sampleDescription = 'M100,100 h20 Z M200,200 h20';
+    private static array $sampleCommands = [
         ['id' => 'M', 'args' => [100.0, 100.0]],
         ['id' => 'h', 'args' => [20.0]],
         ['id' => 'Z', 'args' => []],

--- a/tests/Rasterization/Renderers/MultiPassRendererTest.php
+++ b/tests/Rasterization/Renderers/MultiPassRendererTest.php
@@ -12,11 +12,11 @@ use SVG\Rasterization\Renderers\MultiPassRenderer;
  */
 class MultiPassRendererTest extends \PHPUnit\Framework\TestCase
 {
-    private static $sampleOptions = [
+    private static array $sampleOptions = [
         'option1' => 'option1-value',
         'option2' => 'option2-value',
     ];
-    private static $sampleParams = [
+    private static array $sampleParams = [
         'param1' => 'param1-value',
         'param2' => 'param2-value',
     ];

--- a/tests/SVGTest.php
+++ b/tests/SVGTest.php
@@ -12,8 +12,8 @@ use SVG\SVG;
  */
 class SVGTest extends \PHPUnit\Framework\TestCase
 {
-    private $xml;
-    private $xmlNoDeclaration;
+    private string $xml;
+    private string $xmlNoDeclaration;
 
     public function setUp(): void
     {

--- a/tests/Writing/SVGWriterTest.php
+++ b/tests/Writing/SVGWriterTest.php
@@ -11,7 +11,7 @@ use SVG\Writing\SVGWriter;
  */
 class SVGWriterTest extends \PHPUnit\Framework\TestCase
 {
-    private $xmlDeclaration = '<?xml version="1.0" encoding="utf-8"?>';
+    private string $xmlDeclaration = '<?xml version="1.0" encoding="utf-8"?>';
 
     public function testShouldIncludeXMLDeclaration()
     {


### PR DESCRIPTION
As discussed/requested in #215, PHP 7.3 is dropped,  and typed properties/null coalescing assignment shoud be added where possible.