### PR TITLE
fix: Improve PHP syntax

### DIFF
--- a/src/Nodes/SVGNode.php
+++ b/src/Nodes/SVGNode.php
@@ -11,15 +11,29 @@ use SVG\Shims\Str;
  */
 abstract class SVGNode
 {
-    /** @var SVGNodeContainer $parent The parent node. */
+    /**
+     * @var SVGNodeContainer $parent The parent node.
+     */
     protected ?SVGNodeContainer $parent;
-    /** @var string[] $namespaces A map of custom namespaces to their URIs. */
+
+    /**
+     * @var string[] $namespaces A map of custom namespaces to their URIs.
+     */
     private array $namespaces;
-    /** @var string[] $attributes This node's set of attributes. */
+
+    /**
+     * @var string[] $attributes This node's set of attributes.
+     */
     protected array $attributes;
-    /** @var string[] $styles This node's set of explicit style declarations. */
+
+    /**
+     * @var string[] $styles This node's set of explicit style declarations.
+     */
     protected array $styles;
-    /** @var string $value This node's value */
+
+    /**
+     * @var string $value This node's value
+     */
     protected string $value;
 
     public function __construct()
@@ -276,7 +290,7 @@ abstract class SVGNode
      */
     public function getViewBox(): ?array
     {
-        if ($this->getAttribute('viewBox') == null) {
+        if ($this->getAttribute('viewBox') === null) {
             return null;
         }
         $attr = Str::trim($this->getAttribute('viewBox'));

--- a/src/Nodes/SVGNodeContainer.php
+++ b/src/Nodes/SVGNodeContainer.php
@@ -13,7 +13,9 @@ use SVG\Utilities\SVGStyleParser;
  */
 abstract class SVGNodeContainer extends SVGNode
 {
-    /** @var SVGNode[] $children This node's child nodes. */
+    /**
+     * @var SVGNode[] $children This node's child nodes.
+     */
     protected array $children;
 
     /**

--- a/src/Nodes/Structures/SVGDocumentFragment.php
+++ b/src/Nodes/Structures/SVGDocumentFragment.php
@@ -15,7 +15,9 @@ class SVGDocumentFragment extends SVGNodeContainer
 {
     public const TAG_NAME = 'svg';
 
-    /** @var array $initialStyles A map of style keys to their defaults. */
+    /**
+     * @var array $initialStyles A map of style keys to their defaults.
+     */
     private static array $initialStyles = [
         'fill'          => '#000000',
         'stroke'        => 'none',

--- a/src/Rasterization/Path/PolygonBuilder.php
+++ b/src/Rasterization/Path/PolygonBuilder.php
@@ -136,7 +136,7 @@ class PolygonBuilder
      */
     public function addPoints(array $points): void
     {
-        $this->points = array_merge($this->points, $points);
+        $this->points = [...$this->points, ...$points];
 
         $endPoint = $this->points[count($this->points) - 1];
         $this->posX = $endPoint[0];

--- a/src/Rasterization/Renderers/MultiPassRenderer.php
+++ b/src/Rasterization/Renderers/MultiPassRenderer.php
@@ -220,8 +220,7 @@ abstract class MultiPassRenderer extends Renderer
         // https://svgwg.org/svg2-draft/render.html#ObjectAndGroupOpacityProperties
         // https://drafts.csswg.org/css-color/#transparency
 
-        // null
-        if ($value == null) {
+        if ($value === null) {
             return 1;
         }
 

--- a/src/Rasterization/SVGRasterizer.php
+++ b/src/Rasterization/SVGRasterizer.php
@@ -25,7 +25,9 @@ use SVG\Utilities\Colors\Color;
  */
 class SVGRasterizer
 {
-    /** @var Renderers\Renderer[] $renderers Map of shapes to renderers. */
+    /**
+     * @var Renderers\Renderer[] $renderers Map of shapes to renderers.
+     */
     private static $renderers;
 
     private $fontRegistry;
@@ -44,7 +46,9 @@ class SVGRasterizer
      */
     private int $height;
 
-    /** @var resource $outImage The output image as a GD resource. */
+    /**
+     * @var resource $outImage The output image as a GD resource.
+     */
     private $outImage;
 
     // precomputed properties for getter methods, used often during render

--- a/src/Rasterization/Transform/TransformParser.php
+++ b/src/Rasterization/Transform/TransformParser.php
@@ -18,7 +18,7 @@ final class TransformParser
     public static function parseTransformString(?string $input, Transform $applyTo = null): Transform
     {
         $transform = $applyTo ?? Transform::identity();
-        if ($input == null) {
+        if ($input === null) {
             return $transform;
         }
 

--- a/src/SVG.php
+++ b/src/SVG.php
@@ -14,12 +14,16 @@ use SVG\Writing\SVGWriter;
  */
 class SVG
 {
-    /** @var SVGReader $reader The singleton reader used by this class. */
+    /**
+     * @var SVGReader $reader The singleton reader used by this class.
+     */
     private static $reader;
 
     private static $fontRegistry;
 
-    /** @var SVGDocumentFragment $document This image's root `svg` node/tag. */
+    /**
+     * @var SVGDocumentFragment $document This image's root `svg` node/tag.
+     */
     private SVGDocumentFragment $document;
 
     /**

--- a/src/Utilities/Colors/Color.php
+++ b/src/Utilities/Colors/Color.php
@@ -199,7 +199,7 @@ final class Color
         $s = min(max($s, 0), 1);
         $l = min(max($l, 0), 1);
 
-        if ($s === 0) {
+        if ((float) $s === 0.0) {
             // shortcut if grayscale
             return [$l * 255, $l * 255, $l * 255];
         }

--- a/src/Utilities/Colors/Color.php
+++ b/src/Utilities/Colors/Color.php
@@ -81,7 +81,7 @@ final class Color
             $g = hexdec($str[2] . $str[3]);
             $b = hexdec($str[4] . $str[5]);
             $a = $len === 8 ? hexdec($str[6] . $str[7]) : 255;
-        } elseif ($len === 3 || $len == 4) {
+        } elseif ($len === 3 || $len === 4) {
             $r = hexdec($str[0] . $str[0]);
             $g = hexdec($str[1] . $str[1]);
             $b = hexdec($str[2] . $str[2]);
@@ -199,7 +199,7 @@ final class Color
         $s = min(max($s, 0), 1);
         $l = min(max($l, 0), 1);
 
-        if ($s == 0) {
+        if ($s === 0) {
             // shortcut if grayscale
             return [$l * 255, $l * 255, $l * 255];
         }

--- a/src/Writing/SVGWriter.php
+++ b/src/Writing/SVGWriter.php
@@ -13,7 +13,9 @@ use SVG\Shims\Str;
  */
 class SVGWriter
 {
-    /** @var string $outString The XML output string being written */
+    /**
+     * @var string $outString The XML output string being written
+     */
     private string $outString = '';
 
     public function __construct(bool $isStandalone = true)


### PR DESCRIPTION
Another set of small improvments:
* Use`===` over `==`
* Use strict types over `isset` or `empty`
* Use spreads over `array_merge` (better performance)
* Use multiline docblocks over inlined