### PR TITLE
Correctly render referenced elements in use tagss

### DIFF
--- a/src/Nodes/Structures/SVGUse.php
+++ b/src/Nodes/Structures/SVGUse.php
@@ -22,6 +22,20 @@ class SVGUse extends SVGNodeContainer
      */
     public function rasterize(SVGRasterizer $rasterizer): void
     {
-        // Nothing to rasterize.
+        $element = $this->getAttribute('xlink:href');
+        if(empty($element)) return;
+        
+        /** @var SVGDocumentFragment $root */
+        do {
+            $root = $this->getParent();
+        } while ($root->getParent() != null);
+        $element = $root->getElementById(substr($element, strpos($element, "#") + 1 ?: 0));
+        if(!$element) return;
+
+        TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
+        
+        $element->rasterize($rasterizer);
+        
+        $rasterizer->popTransform();
     }
 }

--- a/src/Nodes/Structures/SVGUse.php
+++ b/src/Nodes/Structures/SVGUse.php
@@ -2,8 +2,10 @@
 
 namespace SVG\Nodes\Structures;
 
+use SVG\Nodes\Embedded\SVGImage;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\Rasterization\SVGRasterizer;
+use SVG\Rasterization\Transform\TransformParser;
 
 /**
  * Represents the SVG tag 'use'.
@@ -18,13 +20,33 @@ class SVGUse extends SVGNodeContainer
     }
 
     /**
+     * @return string|null The referenced element.
+     */
+    public function getHref(): ?string
+    {
+        return $this->getAttribute('xlink:href') ?: $this->getAttribute('href');
+    }
+
+    /**
+     * Sets the element reference.
+     *
+     * @param string|null $href The new element reference.
+     *
+     * @return $this This node instance, for call chaining.
+     */
+    public function setHref(?string $href): SVGUse
+    {
+        return $this->setAttribute('xlink:href', $href);
+    }
+
+    /**
      * @inheritdoc
      */
     public function rasterize(SVGRasterizer $rasterizer): void
     {
-        $element = $this->getAttribute('xlink:href');
+        $element = $this->getHref();
         if(empty($element)) return;
-        
+
         /** @var SVGDocumentFragment $root */
         do {
             $root = $this->getParent();
@@ -33,9 +55,9 @@ class SVGUse extends SVGNodeContainer
         if(!$element) return;
 
         TransformParser::parseTransformString($this->getAttribute('transform'), $rasterizer->pushTransform());
-        
+
         $element->rasterize($rasterizer);
-        
+
         $rasterizer->popTransform();
     }
 }


### PR DESCRIPTION
`<use>` elements lists to reference another element by id. This enables the codebase to render such element when rasterising.

I am aware this is not completely to spec in regards to x,y,width,height but this does the base job for when transforms are at play, which is what my current case exposes. I may look into that in another pr