### PR TITLE
chore: Update CI to run tests on PHP 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Contributions are very welcome. [Find out how to contribute](#contributing).
 
 PHP-SVG is free of dependencies. All it needs is a PHP installation satisfying the following requirements:
 
-* PHP version 7.4 or newer. This library is tested against all versions up to (and including) PHP 8.3.
+* PHP version 7.4 or newer. This library is tested against all versions up to (and including) PHP 8.4.
 * If you wish to load SVG files, or strings containing SVG code, you need to have the
   ['simplexml' PHP extension](https://www.php.net/manual/en/book.simplexml.php).
 * If you wish to use the rasterization feature for converting SVGs to raster images (PNGs, JPEGs, ...), you need to


### PR DESCRIPTION
PHP 8.4 currently has RC4 out, actual release will be later this month. You may want to wait with merging this until 21-11-2024, although I suspect not much will change in the mean time that's relevant to this project.

Please note that `composer.json` requires no changes, hence a release for this PR will not be necessary as users will already be able to install latest release on PHP 8.4. This PR just makes sure future changes are also tested on PHP 8.4. 