### PR TITLE
Added: Text rotate [#80]

### DIFF
--- a/src/Rasterization/Renderers/TextRenderer.php
+++ b/src/Rasterization/Renderers/TextRenderer.php
@@ -64,7 +64,7 @@ class TextRenderer extends MultiPassRenderer
             'size'      => $size,
             'fontPath'  => $fontPath,
             'text'      => $options['text'],
-            'rotation'    => $rotation
+            'rotation'  => $rotation
         ];
     }
 

--- a/src/Rasterization/Renderers/TextRenderer.php
+++ b/src/Rasterization/Renderers/TextRenderer.php
@@ -25,7 +25,7 @@ class TextRenderer extends MultiPassRenderer
      */
     protected function prepareRenderParams(array $options, Transform $transform, ?FontRegistry $fontRegistry): ?array
     {
-        // this assumes there is no rotation or skew, but that's fine, we can't deal with that anyway
+        // only the rotational impact of skew is used
         $size1 = $options['fontSize'];
         $size2 = $size1;
         $transform->resize($size1, $size2);
@@ -55,12 +55,16 @@ class TextRenderer extends MultiPassRenderer
         $y = $options['y'];
         $transform->map($x, $y);
 
+        //get rotation result from transform matrix
+        $rotation = $transform->rotation();
+
         return [
             'x'         => $x - $anchorOffset,
             'y'         => $y,
             'size'      => $size,
             'fontPath'  => $fontPath,
             'text'      => $options['text'],
+            'rotation'    => $rotation
         ];
     }
 
@@ -72,7 +76,7 @@ class TextRenderer extends MultiPassRenderer
         imagettftext(
             $image,
             $params['size'],
-            0,
+            $params['rotation'],
             $params['x'],
             $params['y'],
             $color,
@@ -92,7 +96,7 @@ class TextRenderer extends MultiPassRenderer
 
         for ($c1 = ($x - abs($px)); $c1 <= ($x + abs($px)); $c1++) {
             for ($c2 = ($y - abs($px)); $c2 <= ($y + abs($px)); $c2++) {
-                imagettftext($image, $params['size'], 0, $c1, $c2, $color, $params['fontPath'], $params['text']);
+                imagettftext($image, $params['size'], $params['rotation'], $c1, $c2, $color, $params['fontPath'], $params['text']);
             }
         }
     }

--- a/src/Rasterization/Renderers/TextRenderer.php
+++ b/src/Rasterization/Renderers/TextRenderer.php
@@ -55,7 +55,7 @@ class TextRenderer extends MultiPassRenderer
         $y = $options['y'];
         $transform->map($x, $y);
 
-        //get rotation result from transform matrix
+        //get clockwise rotation result from transform matrix
         $rotation = $transform->rotation();
 
         return [
@@ -76,7 +76,7 @@ class TextRenderer extends MultiPassRenderer
         imagettftext(
             $image,
             $params['size'],
-            $params['rotation'],
+            $params['rotation'] * -1, //counterclockwise
             $params['x'],
             $params['y'],
             $color,
@@ -96,7 +96,16 @@ class TextRenderer extends MultiPassRenderer
 
         for ($c1 = ($x - abs($px)); $c1 <= ($x + abs($px)); $c1++) {
             for ($c2 = ($y - abs($px)); $c2 <= ($y + abs($px)); $c2++) {
-                imagettftext($image, $params['size'], $params['rotation'], $c1, $c2, $color, $params['fontPath'], $params['text']);
+                imagettftext(
+                    $image,
+                    $params['size'],
+                    $params['rotation'] * -1, //counterclockwise
+                    $c1,
+                    $c2,
+                    $color,
+                    $params['fontPath'],
+                    $params['text']
+                );
             }
         }
     }

--- a/src/Rasterization/Transform/Transform.php
+++ b/src/Rasterization/Transform/Transform.php
@@ -211,9 +211,7 @@ class Transform
     {
         $caRotation = atan2($this->matrix[2], $this->matrix[0]);
         $bdRotation = atan2(-($this->matrix[1]), $this->matrix[3]);
-        $result = ($caRotation + $bdRotation) / 2 * 180 / M_PI;
-
-        return $result;
+        return ($caRotation + $bdRotation) / 2 * 180 / M_PI;
     }
 
     /**

--- a/src/Rasterization/Transform/Transform.php
+++ b/src/Rasterization/Transform/Transform.php
@@ -205,13 +205,29 @@ class Transform
     /**
      * Calculate the resulting rotation using the yaw rotation matrix
      *
-     * @return float
+     * @return float clockwise rotation
      */
     public function rotation(): float
     {
-        $caRotation = atan2($this->matrix[2], $this->matrix[0]);
-        $bdRotation = atan2(-($this->matrix[1]), $this->matrix[3]);
-        return ($caRotation + $bdRotation) / 2 * 180 / M_PI;
+        /*
+         * This is the counterclockwise rotation matrices,
+         *  although the $radians in the function rotate() is a clockwise value,
+         *  the matrix presents is counterclockwise,
+         *  using these matrices, the result is clockwise.
+         *
+         *       |cos(θ) -sin(θ)  0|     |a -c  0|
+         * R  =  |sin(θ)  cos(θ)  0|  =  |b  d  0|
+         *       |0       0       1|     |0  0  1|
+         *
+         * Note: atan2(y, x) takes params in the y, x order.
+         * First we calculate the rotation effect of skewX/c and scaleX/a into radians: atan2(-c, a)
+         * Then we calculate the rotation effect of skewY/b and scaleY/d into radians: atan2(b, d)
+         * Last we average that and convert it to degree rotation: Ave(caRadian, bdRadian) * 180 / M_PI
+         */
+
+        $caRadian = atan2(-$this->matrix[2], $this->matrix[0]);
+        $bdRadian = atan2($this->matrix[1], $this->matrix[3]);
+        return ($caRadian + $bdRadian) / 2 * 180 / M_PI;
     }
 
     /**

--- a/src/Rasterization/Transform/Transform.php
+++ b/src/Rasterization/Transform/Transform.php
@@ -203,6 +203,20 @@ class Transform
     }
 
     /**
+     * Calculate the resulting rotation using the yaw rotation matrix
+     *
+     * @return float
+     */
+    public function rotation(): float
+    {
+        $caRotation = atan2($this->matrix[2], $this->matrix[0]);
+        $bdRotation = atan2(-($this->matrix[1]), $this->matrix[3]);
+        $result = ($caRotation + $bdRotation) / 2 * 180 / M_PI;
+
+        return $result;
+    }
+
+    /**
      * Apply a horizontal skew to this transform. This object will be mutated as a result of this operation.
      * This is the same as post-multiplying this transform with another transform representing a pure horizontal skew.
      *


### PR DESCRIPTION
### Added: Text rotate [#80]

Text rotation was added by calculating the resulting rotation after all transformations were calculated.
So we are using the resulting matrix data in the `Transform` to get our final rotation.

The `rotation` function in the `Transform` class is universal, so it should be usable for other elements.