### PR TITLE
fix: Fix PHP 8.4 deprecations

### DIFF
--- a/src/Nodes/SVGNodeContainer.php
+++ b/src/Nodes/SVGNodeContainer.php
@@ -41,7 +41,7 @@ abstract class SVGNodeContainer extends SVGNode
      *
      * @return $this This node instance, for call chaining.
      */
-    public function addChild(SVGNode $node, int $index = null): SVGNodeContainer
+    public function addChild(SVGNode $node, ?int $index = null): SVGNodeContainer
     {
         if ($node === $this || $node->parent === $this) {
             return $this;

--- a/src/Nodes/Shapes/SVGPath.php
+++ b/src/Nodes/Shapes/SVGPath.php
@@ -19,7 +19,7 @@ class SVGPath extends SVGNodeContainer
     /**
      * @param string|null $d The path description.
      */
-    public function __construct(string $d = null)
+    public function __construct(?string $d = null)
     {
         parent::__construct();
 

--- a/src/Nodes/Shapes/SVGPolygonalShape.php
+++ b/src/Nodes/Shapes/SVGPolygonalShape.php
@@ -12,13 +12,13 @@ use SVG\Shims\Str;
 abstract class SVGPolygonalShape extends SVGNodeContainer
 {
     /**
-     * @param array[] $points Array of points (float 2-tuples).
+     * @param array[]|null $points Array of points (float 2-tuples).
      */
-    public function __construct(array $points = null)
+    public function __construct(?array $points = null)
     {
         parent::__construct();
 
-        if (isset($points)) {
+        if ($points !== null) {
             $this->setAttribute('points', self::joinPoints($points));
         }
     }

--- a/src/Nodes/Structures/SVGClipPath.php
+++ b/src/Nodes/Structures/SVGClipPath.php
@@ -12,7 +12,7 @@ class SVGClipPath extends SVGNodeContainer
 {
     public const TAG_NAME = 'clipPath';
 
-    public function __construct(string $id = null)
+    public function __construct(?string $id = null)
     {
         parent::__construct();
 

--- a/src/Rasterization/Transform/TransformParser.php
+++ b/src/Rasterization/Transform/TransformParser.php
@@ -15,7 +15,7 @@ final class TransformParser
      * @param Transform|null $applyTo The optional starting Transform. If not provided, the identity will be used.
      * @return Transform Either the mutated argument transform, or the newly computed transform.
      */
-    public static function parseTransformString(?string $input, Transform $applyTo = null): Transform
+    public static function parseTransformString(?string $input, ?Transform $applyTo = null): Transform
     {
         $transform = $applyTo ?? Transform::identity();
         if ($input === null) {


### PR DESCRIPTION
Fix `Deprecated: SVG\Nodes\Structures\SVGClipPath::__construct(): Implicitly marking parameter $id as nullable is deprecated, the explicit nullable type must be used instead` and more